### PR TITLE
add local java sdk module for develop android sdk

### DIFF
--- a/TesterApp/build.gradle
+++ b/TesterApp/build.gradle
@@ -51,8 +51,6 @@ android {
 }
 
 dependencies {
-
-//    implementation 'io.hackle:hackle-android-sdk:2.47.1'
     implementation project(':hackle-android-sdk')
     implementation "com.google.code.gson:gson:2.8.6"
     implementation(platform("com.google.firebase:firebase-bom:32.3.1"))

--- a/hackle-android-sdk/build.gradle
+++ b/hackle-android-sdk/build.gradle
@@ -40,7 +40,7 @@ android {
     }
 }
 
-def hasLocalSdk = getHackleJavaSdkPath() != null
+def hasLocalSdk = getLocalProperty('hackle.java.sdk.path') != null
 
 dependencies {
     // if hackle.java.sdk.path exist in local.properties, use local hackle-sdk-common and hackle-sdk-core
@@ -143,12 +143,16 @@ signing {
     sign publishing.publications
 }
 
-def getHackleJavaSdkPath() {
-    def properties = new Properties()
-    def localPropertiesFile = rootProject.file('local.properties')
-    if (localPropertiesFile.exists()) {
-        properties.load(localPropertiesFile.newDataInputStream())
-        return properties.getProperty('hackle.java.sdk.path')
+def getLocalProperty(String key) {
+    if (key == null) {
+        return null
+    }
+
+    Properties properties = new Properties()
+    def localProperties = file("local.properties")
+    if (localProperties.exists()) {
+        properties.load(localProperties.newDataInputStream())
+        return properties.getProperty(key)
     }
     return null
 }

--- a/hackle-android-sdk/build.gradle
+++ b/hackle-android-sdk/build.gradle
@@ -43,7 +43,7 @@ android {
 def hasLocalSdk = getHackleJavaSdkPath() != null
 
 dependencies {
-    // if settings-local.gradle exists, use local hackle-sdk-common and hackle-sdk-core
+    // if hackle.java.sdk.path exist in local.properties, use local hackle-sdk-common and hackle-sdk-core
     if(hasLocalSdk)  {
         debugApi "io.hackle:hackle-sdk-common"
         debugImplementation "io.hackle:hackle-sdk-core"

--- a/hackle-android-sdk/build.gradle
+++ b/hackle-android-sdk/build.gradle
@@ -41,9 +41,11 @@ android {
 }
 
 dependencies {
+    debugApi "io.hackle:hackle-sdk-common"
+    debugImplementation "io.hackle:hackle-sdk-core"
 
-    api "io.hackle:hackle-sdk-common:2.25.7"
-    implementation "io.hackle:hackle-sdk-core:2.25.7"
+    releaseApi "io.hackle:hackle-sdk-common:2.25.7"
+    releaseImplementation "io.hackle:hackle-sdk-core:2.25.7"
 
     implementation 'com.squareup.okhttp3:okhttp:3.12.2'
     implementation "com.google.android.gms:play-services-base:17.3.0"

--- a/hackle-android-sdk/build.gradle
+++ b/hackle-android-sdk/build.gradle
@@ -40,12 +40,21 @@ android {
     }
 }
 
-dependencies {
-    debugApi "io.hackle:hackle-sdk-common"
-    debugImplementation "io.hackle:hackle-sdk-core"
+def hasLocalSdk = getHackleJavaSdkPath() != null
 
-    releaseApi "io.hackle:hackle-sdk-common:2.25.7"
-    releaseImplementation "io.hackle:hackle-sdk-core:2.25.7"
+dependencies {
+    // if settings-local.gradle exists, use local hackle-sdk-common and hackle-sdk-core
+    if(hasLocalSdk)  {
+        debugApi "io.hackle:hackle-sdk-common"
+        debugImplementation "io.hackle:hackle-sdk-core"
+
+        releaseApi "io.hackle:hackle-sdk-common:2.25.7"
+        releaseImplementation "io.hackle:hackle-sdk-core:2.25.7"
+    } else {
+        api "io.hackle:hackle-sdk-common:2.25.7"
+        implementation "io.hackle:hackle-sdk-core:2.25.7"
+    }
+
 
     implementation 'com.squareup.okhttp3:okhttp:3.12.2'
     implementation "com.google.android.gms:play-services-base:17.3.0"
@@ -132,4 +141,14 @@ signing {
     def signingPassword = System.getenv("SIGNING_PASSWORD")
     useInMemoryPgpKeys(signingKey, signingPassword)
     sign publishing.publications
+}
+
+def getHackleJavaSdkPath() {
+    def properties = new Properties()
+    def localPropertiesFile = rootProject.file('local.properties')
+    if (localPropertiesFile.exists()) {
+        properties.load(localPropertiesFile.newDataInputStream())
+        return properties.getProperty('hackle.java.sdk.path')
+    }
+    return null
 }

--- a/settings.gradle
+++ b/settings.gradle
@@ -2,7 +2,7 @@ include ':hackle-android-sdk'
 rootProject.name = "hackle-android-sdk"
 include ':TesterApp'
 
-def hackleJavaSdkPath = getLocalProperty('hackle.sdk.local.path')
+def hackleJavaSdkPath = getLocalProperty('hackle.java.sdk.path')
 if (hackleJavaSdkPath) {
     // hackle-java-sdk settings.gradle
     includeBuild(hackleJavaSdkPath) {
@@ -14,6 +14,10 @@ if (hackleJavaSdkPath) {
 }
 
 def getLocalProperty(String key) {
+    if (key == null) {
+        return null
+    }
+
     Properties properties = new Properties()
     def localProperties = file("local.properties")
     if (localProperties.exists()) {

--- a/settings.gradle
+++ b/settings.gradle
@@ -1,3 +1,11 @@
 include ':hackle-android-sdk'
 rootProject.name = "hackle-android-sdk"
 include ':TesterApp'
+
+// hackle-java-sdk settings.gradle
+includeBuild('../hackle-java-sdk') {
+    dependencySubstitution {
+        substitute module('io.hackle:hackle-sdk-common') using project(':hackle-sdk-common')
+        substitute module('io.hackle:hackle-sdk-core') using project(':hackle-sdk-core')
+    }
+}

--- a/settings.gradle
+++ b/settings.gradle
@@ -2,10 +2,23 @@ include ':hackle-android-sdk'
 rootProject.name = "hackle-android-sdk"
 include ':TesterApp'
 
-// hackle-java-sdk settings.gradle
-includeBuild('../hackle-java-sdk') {
-    dependencySubstitution {
-        substitute module('io.hackle:hackle-sdk-common') using project(':hackle-sdk-common')
-        substitute module('io.hackle:hackle-sdk-core') using project(':hackle-sdk-core')
+def hackleJavaSdkPath = getLocalProperty('hackle.sdk.local.path')
+if (hackleJavaSdkPath) {
+    // hackle-java-sdk settings.gradle
+    includeBuild(hackleJavaSdkPath) {
+        dependencySubstitution {
+            substitute module('io.hackle:hackle-sdk-common') using project(':hackle-sdk-common')
+            substitute module('io.hackle:hackle-sdk-core') using project(':hackle-sdk-core')
+        }
     }
+}
+
+def getLocalProperty(String key) {
+    Properties properties = new Properties()
+    def localProperties = file("local.properties")
+    if (localProperties.exists()) {
+        properties.load(localProperties.newDataInputStream())
+        return properties.getProperty(key)
+    }
+    return null
 }


### PR DESCRIPTION
## 개요
로컬에서 개발할 때 로컬 경로 상의 java sdk의 common과 core 모듈을 직접 참조할 수 있게 gradle 수정

## 작업 내용
- `local.properties`에 `hackle.java.sdk.path` 가 있으면 해당 경로에서 java sdk를 참조해서 프로젝트에 아래 모듈 추가
  - `hackle-sdk-common`
  - `hackle-sdk-core`
- debug 빌드에 한해서만 로컬 경로의 모듈을 사용하도록 제한
- release 빌드는 기존과 동일하게 maven에서 jar를 다운받아 사용
- `local.properties`에 `hackle.java.sdk.path` 가 없으면 기존과 동일하게 maven에서 jar를 다운받아 사용

## 참고
- [jira ticket](https://dalbang.atlassian.net/browse/HACKLE-11378)
- gradle 수정 후 sync 및 clean을 해야 수정 사항이 정상 반영 됩니다.
- `hackle.java.sdk.path` 예시
  - `hackle.java.sdk.path=../hackle-java-sdk`
  - `""` 가 있으면 경로 참조를 실패합니다.