### PR TITLE
add phone number support

### DIFF
--- a/.gitignore
+++ b/.gitignore
@@ -14,3 +14,6 @@
 .externalNativeBuild
 .cxx
 local.properties
+
+.qodo
+.java-version

--- a/hackle-android-sdk/.gitignore
+++ b/hackle-android-sdk/.gitignore
@@ -1,1 +1,2 @@
 /build
+.qodo

--- a/hackle-android-sdk/src/main/java/io/hackle/android/Hackle.kt
+++ b/hackle-android-sdk/src/main/java/io/hackle/android/Hackle.kt
@@ -52,6 +52,9 @@ fun Hackle.setDeviceId(deviceId: String) = app.setDeviceId(deviceId)
 fun Hackle.setUserProperty(key: String, value: Any?) = app.setUserProperty(key, value)
 fun Hackle.resetUser() = app.resetUser()
 
+fun Hackle.setPhoneNumber(phoneNumber: String) = app.setPhoneNumber(phoneNumber)
+fun Hackle.unsetPhoneNumber() = app.unsetPhoneNumber()
+
 fun Hackle.fetch(callback: Runnable? = null) = app.fetch(callback)
 
 @Deprecated(

--- a/hackle-android-sdk/src/main/java/io/hackle/android/HackleApp.kt
+++ b/hackle-android-sdk/src/main/java/io/hackle/android/HackleApp.kt
@@ -17,6 +17,7 @@ import io.hackle.android.internal.model.Device
 import io.hackle.android.internal.model.Sdk
 import io.hackle.android.internal.monitoring.metric.DecisionMetrics
 import io.hackle.android.internal.notification.NotificationManager
+import io.hackle.android.internal.pii.PIIEventManager
 import io.hackle.android.internal.push.token.PushTokenManager
 import io.hackle.android.internal.remoteconfig.HackleRemoteConfigImpl
 import io.hackle.android.internal.session.SessionManager
@@ -57,6 +58,7 @@ class HackleApp internal constructor(
     private val eventProcessor: DefaultEventProcessor,
     private val pushTokenManager: PushTokenManager,
     private val notificationManager: NotificationManager,
+    private val piiEventManager: PIIEventManager,
     private val fetchThrottler: Throttler,
     private val device: Device,
     internal val userExplorer: HackleUserExplorer,
@@ -145,6 +147,14 @@ class HackleApp internal constructor(
             log.error { "Unexpected exception while reset user: $e" }
             callback?.run()
         }
+    }
+
+    fun setPhoneNumber(phoneNumber: String) {
+        piiEventManager.setPhoneNumber(phoneNumber, user, clock.currentMillis())
+    }
+
+    fun unsetPhoneNumber() {
+        piiEventManager.unsetPhoneNumber(user, clock.currentMillis())
     }
 
     private fun syncIfNeeded(userUpdated: Updated<User>, callback: Runnable?) {

--- a/hackle-android-sdk/src/main/java/io/hackle/android/HackleApp.kt
+++ b/hackle-android-sdk/src/main/java/io/hackle/android/HackleApp.kt
@@ -149,12 +149,26 @@ class HackleApp internal constructor(
         }
     }
 
-    fun setPhoneNumber(phoneNumber: String) {
-        piiEventManager.setPhoneNumber(phoneNumber, user, clock.currentMillis())
+    fun setPhoneNumber(phoneNumber: String, callback: Runnable? = null) {
+        try {
+            piiEventManager.setPhoneNumber(phoneNumber, user, clock.currentMillis())
+            eventProcessor.flush()
+        } catch (e: Exception) {
+            log.error { "Unexpected exception while set phoneNumber: $e" }
+        } finally {
+            callback?.run()
+        }
     }
 
-    fun unsetPhoneNumber() {
-        piiEventManager.unsetPhoneNumber(user, clock.currentMillis())
+    fun unsetPhoneNumber(callback: Runnable? = null) {
+        try {
+            piiEventManager.unsetPhoneNumber(user, clock.currentMillis())
+            eventProcessor.flush()
+        } catch (e: Exception) {
+            log.error { "Unexpected exception while unset phoneNumber: $e" }
+        } finally {
+            callback?.run()
+        }
     }
 
     private fun syncIfNeeded(userUpdated: Updated<User>, callback: Runnable?) {

--- a/hackle-android-sdk/src/main/java/io/hackle/android/HackleApps.kt
+++ b/hackle-android-sdk/src/main/java/io/hackle/android/HackleApps.kt
@@ -30,6 +30,7 @@ import io.hackle.android.internal.model.Device
 import io.hackle.android.internal.model.Sdk
 import io.hackle.android.internal.monitoring.metric.MonitoringMetricRegistry
 import io.hackle.android.internal.notification.NotificationManager
+import io.hackle.android.internal.pii.PIIEventManager
 import io.hackle.android.internal.push.PushEventTracker
 import io.hackle.android.internal.push.token.PushTokenFetchers
 import io.hackle.android.internal.push.token.PushTokenManager
@@ -362,6 +363,12 @@ internal object HackleApps {
         NotificationHandler.getInstance(context)
             .setNotificationDataReceiver(notificationManager)
 
+        // PII
+        val piiEventManager = PIIEventManager(
+            core = core,
+            userManager = userManager
+        )
+
         // UserExplorer
         val devToolsApi = DevToolsApi(
             sdk = sdk,
@@ -415,6 +422,7 @@ internal object HackleApps {
             eventProcessor = eventProcessor,
             pushTokenManager = pushTokenManager,
             notificationManager = notificationManager,
+            piiEventManager = piiEventManager,
             fetchThrottler = fetchThrottler,
             device = device,
             userExplorer = userExplorer,

--- a/hackle-android-sdk/src/main/java/io/hackle/android/internal/bridge/HackleBridge.kt
+++ b/hackle-android-sdk/src/main/java/io/hackle/android/internal/bridge/HackleBridge.kt
@@ -59,6 +59,16 @@ internal class HackleBridge(val app: HackleApp) {
                 BridgeResponse.success()
             }
 
+            SET_PHONE_NUMBER -> {
+                setPhoneNumber(parameters)
+                BridgeResponse.success()
+            }
+
+            UNSET_PHONE_NUMBER -> {
+                app.unsetPhoneNumber()
+                BridgeResponse.success()
+            }
+
             VARIATION -> {
                 val data = variation(parameters)
                 BridgeResponse.success(data)
@@ -125,6 +135,11 @@ internal class HackleBridge(val app: HackleApp) {
         val dto = checkNotNull(parameters["operations"] as? PropertyOperationsDto)
         val operations = PropertyOperations.from(dto)
         app.updateUserProperties(operations)
+    }
+
+    private fun setPhoneNumber(parameters: Map<String, Any>) {
+        val phoneNumber = checkNotNull(parameters["phoneNumber"] as? String)
+        app.setPhoneNumber(phoneNumber)
     }
 
     private fun variation(parameters: Map<String, Any>): String {

--- a/hackle-android-sdk/src/main/java/io/hackle/android/internal/bridge/model/BridgeInvocation.kt
+++ b/hackle-android-sdk/src/main/java/io/hackle/android/internal/bridge/model/BridgeInvocation.kt
@@ -13,6 +13,8 @@ internal class BridgeInvocation(string: String) {
         SET_USER_PROPERTY("setUserProperty"),
         UPDATE_USER_PROPERTY("updateUserProperties"),
         RESET_USER("resetUser"),
+        SET_PHONE_NUMBER("setPhoneNumber"),
+        UNSET_PHONE_NUMBER("unsetPhoneNumber"),
         VARIATION("variation"),
         VARIATION_DETAIL("variationDetail"),
         IS_FEATURE_ON("isFeatureOn"),

--- a/hackle-android-sdk/src/main/java/io/hackle/android/internal/pii/PIIEventManager.kt
+++ b/hackle-android-sdk/src/main/java/io/hackle/android/internal/pii/PIIEventManager.kt
@@ -6,7 +6,6 @@ import io.hackle.sdk.common.Event
 import io.hackle.sdk.common.PropertyOperations
 import io.hackle.sdk.common.User
 import io.hackle.sdk.core.HackleCore
-import io.hackle.sdk.core.internal.log.Logger
 
 internal class PIIEventManager(
     private val userManager: UserManager,
@@ -32,10 +31,6 @@ internal class PIIEventManager(
     private fun track(event: Event, user: User, timestamp: Long) {
         val hackleUser = userManager.toHackleUser(user)
         core.track(event, hackleUser, timestamp)
-    }
-
-    companion object {
-        private val log = Logger<PIIEventManager>()
     }
 }
 

--- a/hackle-android-sdk/src/main/java/io/hackle/android/internal/pii/PIIEventManager.kt
+++ b/hackle-android-sdk/src/main/java/io/hackle/android/internal/pii/PIIEventManager.kt
@@ -39,11 +39,11 @@ internal class PIIEventManager(
     }
 }
 
-enum class PIIProperty(val key: String) {
+internal enum class PIIProperty(val key: String) {
     PHONE_NUMBER("\$phone_number")
 }
 
-fun PropertyOperations.toSecuredEvent(): Event {
+private fun PropertyOperations.toSecuredEvent(): Event {
     val builder = Event.builder("\$secured_properties")
     for ((operation, properties) in asMap()) {
         builder.property(operation.key, properties)

--- a/hackle-android-sdk/src/main/java/io/hackle/android/internal/pii/PIIEventManager.kt
+++ b/hackle-android-sdk/src/main/java/io/hackle/android/internal/pii/PIIEventManager.kt
@@ -1,0 +1,52 @@
+package io.hackle.android.internal.pii
+
+import io.hackle.android.internal.pii.phonenumber.PhoneNumber
+import io.hackle.android.internal.user.UserManager
+import io.hackle.sdk.common.Event
+import io.hackle.sdk.common.PropertyOperations
+import io.hackle.sdk.common.User
+import io.hackle.sdk.core.HackleCore
+import io.hackle.sdk.core.internal.log.Logger
+
+internal class PIIEventManager(
+    private val userManager: UserManager,
+    private val core: HackleCore,
+) {
+    fun setPhoneNumber(phoneNumber: String, user: User, timestamp: Long) {
+        val filteredPhoneNumber = PhoneNumber.filtered(phoneNumber)
+        val properties = PropertyOperations.builder()
+            .set(PIIProperty.PHONE_NUMBER.key, filteredPhoneNumber)
+            .build()
+        val event = properties.toSecuredEvent()
+        track(event, user, timestamp)
+    }
+
+    fun unsetPhoneNumber(user: User, timestamp: Long) {
+        val properties = PropertyOperations.builder()
+            .unset(PIIProperty.PHONE_NUMBER.key)
+            .build()
+        val event = properties.toSecuredEvent()
+        track(event, user, timestamp)
+    }
+
+    private fun track(event: Event, user: User, timestamp: Long) {
+        val hackleUser = userManager.toHackleUser(user)
+        core.track(event, hackleUser, timestamp)
+    }
+
+    companion object {
+        private val log = Logger<PIIEventManager>()
+    }
+}
+
+enum class PIIProperty(val key: String) {
+    PHONE_NUMBER("\$phone_number")
+}
+
+fun PropertyOperations.toSecuredEvent(): Event {
+    val builder = Event.builder("\$secured_properties")
+    for ((operation, properties) in asMap()) {
+        builder.property(operation.key, properties)
+    }
+    return builder.build()
+}

--- a/hackle-android-sdk/src/main/java/io/hackle/android/internal/pii/phonenumber/PhoneNumber.kt
+++ b/hackle-android-sdk/src/main/java/io/hackle/android/internal/pii/phonenumber/PhoneNumber.kt
@@ -1,0 +1,11 @@
+package io.hackle.android.internal.pii.phonenumber
+
+class PhoneNumber {
+    companion object {
+        fun filtered(phoneNumber: String): String {
+            return phoneNumber
+                .filter { it.isDigit() || it == '+'  }
+                .take(16)
+        }
+    }
+}

--- a/hackle-android-sdk/src/main/java/io/hackle/android/internal/pii/phonenumber/PhoneNumber.kt
+++ b/hackle-android-sdk/src/main/java/io/hackle/android/internal/pii/phonenumber/PhoneNumber.kt
@@ -1,6 +1,6 @@
 package io.hackle.android.internal.pii.phonenumber
 
-class PhoneNumber {
+internal class PhoneNumber {
     companion object {
         fun filtered(phoneNumber: String): String {
             return phoneNumber

--- a/hackle-android-sdk/src/test/java/io/hackle/android/HackleAppTest.kt
+++ b/hackle-android-sdk/src/test/java/io/hackle/android/HackleAppTest.kt
@@ -6,6 +6,7 @@ import io.hackle.android.internal.event.DefaultEventProcessor
 import io.hackle.android.internal.model.AndroidBuild
 import io.hackle.android.internal.model.Sdk
 import io.hackle.android.internal.notification.NotificationManager
+import io.hackle.android.internal.pii.PIIEventManager
 import io.hackle.android.internal.push.token.PushTokenManager
 import io.hackle.android.internal.remoteconfig.HackleRemoteConfigImpl
 import io.hackle.android.internal.session.Session
@@ -70,6 +71,9 @@ class HackleAppTest {
 
     @RelaxedMockK
     private lateinit var notificationManager: NotificationManager
+    
+    @RelaxedMockK
+    private lateinit var piiEventManager: PIIEventManager
 
     @RelaxedMockK
     private lateinit var userExplorer: HackleUserExplorer
@@ -101,6 +105,7 @@ class HackleAppTest {
             eventProcessor,
             pushTokenManager,
             notificationManager,
+            piiEventManager,
             fetchThrottler,
             MockDevice("hackle_device_id", emptyMap()),
             userExplorer,
@@ -422,7 +427,22 @@ class HackleAppTest {
     }
 
     @Test
-    fun `variation`() {
+    fun setPhoneNumber() {
+        val phoneNumber = "+821012345678"
+        sut.setPhoneNumber(phoneNumber)
+
+        verify(exactly = 1) { piiEventManager.setPhoneNumber(phoneNumber, any(), any()) }
+    }
+
+    @Test
+    fun unsetPhoneNumber() {
+        sut.unsetPhoneNumber()
+
+        verify(exactly = 1) { piiEventManager.unsetPhoneNumber(any(), any()) }
+    }
+
+    @Test
+    fun variation() {
         // given
         val hackleUser = HackleUser.builder().identifier(IdentifierType.ID, "42").build()
         every { userManager.resolve(any()) } returns hackleUser

--- a/hackle-android-sdk/src/test/java/io/hackle/android/internal/pii/PIIEventManagerTest.kt
+++ b/hackle-android-sdk/src/test/java/io/hackle/android/internal/pii/PIIEventManagerTest.kt
@@ -1,0 +1,79 @@
+
+package io.hackle.android.internal.pii
+
+import io.hackle.android.internal.user.UserManager
+import io.hackle.sdk.common.Event
+import io.hackle.sdk.common.User
+import io.hackle.sdk.core.HackleCore
+import io.mockk.every
+import io.mockk.mockk
+import io.mockk.verify
+import org.junit.Before
+import org.junit.Test
+import strikt.api.expectThat
+import strikt.assertions.isEqualTo
+
+class PIIEventManagerTest {
+
+    private lateinit var userManager: UserManager
+    private lateinit var core: HackleCore
+    private lateinit var sut: PIIEventManager
+
+    @Before
+    fun before() {
+        userManager = mockk()
+        core = mockk(relaxed = true)
+        sut = PIIEventManager(userManager, core)
+    }
+
+    @Test
+    fun `set phone number`() {
+        // given
+        every { userManager.toHackleUser(any()) } returns mockk()
+        val user = User.builder().deviceId("device_id").build()
+        val phoneNumber = "0101234567890"
+
+        // when
+        sut.setPhoneNumber(phoneNumber, user, 42)
+
+        // then
+        verify(exactly = 1) {
+            core.track(
+                event = withArg {
+                    expectThat(it).isEqualTo(
+                        Event.builder("\$secured_properties")
+                            .property("\$set", mapOf("\$phone_number" to phoneNumber))
+                            .build()
+                    )
+                },
+                user = any(),
+                timestamp = 42
+            )
+        }
+    }
+
+    @Test
+    fun `unset phone number`() {
+        // given
+        every { userManager.toHackleUser(any()) } returns mockk()
+        val user = User.builder().deviceId("device_id").build()
+
+        // when
+        sut.unsetPhoneNumber(user, 42)
+
+        // then
+        verify(exactly = 1) {
+            core.track(
+                event = withArg {
+                    expectThat(it).isEqualTo(
+                        Event.builder("\$secured_properties")
+                            .property("\$unset", mapOf("\$phone_number" to "-"))
+                            .build()
+                    )
+                },
+                user = any(),
+                timestamp = 42
+            )
+        }
+    }
+}

--- a/hackle-android-sdk/src/test/java/io/hackle/android/internal/pii/phonenumber/PhoneNumberTest.kt
+++ b/hackle-android-sdk/src/test/java/io/hackle/android/internal/pii/phonenumber/PhoneNumberTest.kt
@@ -1,0 +1,56 @@
+package io.hackle.android.internal.pii.phonenumber
+
+import junit.framework.TestCase.assertEquals
+import org.junit.Test
+
+class PhoneNumberTest {
+    @Test
+    fun `filtered_phone_number_with_+`() {
+        // Given
+        val phoneNumbers = arrayOf(
+            "+821012345678",
+            "+82-10-1234-5678",
+            "+82 10 1234 5678",
+            "+82 10 1234-5678",
+            "+82(10)12345678",
+            "+82(10)1234-5678",
+            "+82(10)1234 5678",
+            "+82-10-1234-5678aaa",
+            "aaa+82 10 1234 5678",
+        )
+        val expected = "+821012345678"
+
+        for (phoneNumber in phoneNumbers) {
+            // When
+            val result = PhoneNumber.filtered(phoneNumber)
+
+            // Then
+            assertEquals(result, expected)
+        }
+    }
+
+    @Test
+    fun filtered_phone_number() {
+        // Given
+        val phoneNumbers = arrayOf(
+            "01012345678",
+            "01012345678",
+            "010-1234-5678",
+            "010 1234 5678",
+            "010 1234-5678",
+            "010(1234)5678",
+            "010(1234)5678",
+            "010(1234)5678aaa",
+            "aaa010 1234 5678",
+        )
+        val expected = "01012345678"
+
+        for (phoneNumber in phoneNumbers) {
+            // When
+            val result = PhoneNumber.filtered(phoneNumber)
+
+            // Then
+            assertEquals(result, expected)
+        }
+    }
+}


### PR DESCRIPTION
## 개요
- 전화번호 수집 기능 추가

## 작업 내용
### PIIEventManger 추가
- PII(Personally Identifiable Information)를 관리하기 위한 객체입니다.
- 현재는 `setPhoneNumber`와 `unsetPhoneNumber` 만 지원합니다.

### `setPhoneNumber` 추가
- 전화번호에 자주 사용되는 `()-.`과 공백을 필터링합니다. +는 유지합니다.
- 최대 16자리까지만 PhoneNumber 지정이 가능하며, 필터링 된 문자열에서 앞에서 16자리까지만 유지하고 뒤는 삭제합니다.
- `$secured_properties`로 `$phone_number` set 이벤트를 발생시킵니다.

### `unsetPhoneNumber` 추가
- `$secured_properties`로 `$phone_number` unset 이벤트를 발생시킵니다.

## 참고
- PushEventTracker를 참고해서 추가했습니다.