### PR TITLE
add margin when enableEdgeToEdge

### DIFF
--- a/TesterApp/build.gradle
+++ b/TesterApp/build.gradle
@@ -7,12 +7,12 @@ Properties properties = new Properties()
 properties.load(project.rootProject.file('local.properties').newDataInputStream())
 
 android {
-    compileSdkVersion 31
+    compileSdkVersion 35
 
     defaultConfig {
         applicationId "io.hackle.android.sdk.tester"
         minSdkVersion 16
-        targetSdkVersion 31
+        targetSdkVersion 35
         versionCode 1
         versionName "1.0"
 
@@ -55,7 +55,6 @@ dependencies {
     implementation "com.google.code.gson:gson:2.8.6"
     implementation(platform("com.google.firebase:firebase-bom:32.3.1"))
 
-    // For Test ============================================================
     implementation 'androidx.core:core-ktx:1.7.0'
     implementation 'androidx.appcompat:appcompat:1.4.1'
     implementation 'com.google.android.material:material:1.5.0-alpha01'

--- a/TesterApp/src/main/AndroidManifest.xml
+++ b/TesterApp/src/main/AndroidManifest.xml
@@ -1,5 +1,6 @@
 <?xml version="1.0" encoding="utf-8"?>
 <manifest xmlns:android="http://schemas.android.com/apk/res/android"
+    xmlns:tools="http://schemas.android.com/tools"
     package="io.hackle.android.sdk.tester">
 
     <uses-permission android:name="android.permission.SYSTEM_ALERT_WINDOW" />
@@ -7,16 +8,18 @@
 
     <application
         android:allowBackup="true"
-        android:debuggable="true"
         android:icon="@mipmap/ic_launcher"
         android:label="@string/app_name"
         android:roundIcon="@mipmap/ic_launcher_round"
         android:supportsRtl="true"
-        android:theme="@style/Theme.Androidsdktester.NoActionBar">
+        android:usesCleartextTraffic="true"
+        android:theme="@style/Theme.Androidsdktester.NoActionBar"
+        tools:targetApi="23">
         <activity
             android:name=".MainActivity"
-            android:screenOrientation="sensor"
-            android:exported="true">
+            android:exported="true"
+            android:windowSoftInputMode="stateHidden|adjustResize"
+            >
             <intent-filter>
                 <action android:name="android.intent.action.MAIN" />
 

--- a/TesterApp/src/main/java/io/hackle/android/sdk/tester/MainActivity.kt
+++ b/TesterApp/src/main/java/io/hackle/android/sdk/tester/MainActivity.kt
@@ -1,13 +1,20 @@
 package io.hackle.android.sdk.tester
 
+import android.annotation.SuppressLint
 import android.content.Intent
+import android.os.Build
 import android.os.Bundle
 import android.util.Log
 import android.widget.Button
+import android.widget.EditText
 import android.widget.TextView
+import androidx.annotation.RequiresApi
 import androidx.appcompat.app.AppCompatActivity
+import androidx.core.view.ViewCompat
+import androidx.core.view.WindowInsetsCompat
 import io.hackle.android.Hackle
 import io.hackle.android.HackleApp
+import io.hackle.android.HackleAppMode
 import io.hackle.android.HackleConfig
 import io.hackle.android.app
 import io.hackle.sdk.common.HackleInAppMessage
@@ -17,7 +24,6 @@ import io.hackle.sdk.common.HackleInAppMessageView
 import io.hackle.sdk.common.HacklePushSubscriptionStatus
 import java.util.concurrent.Executors
 import kotlin.concurrent.thread
-//import io.hackle.android.explorer.HackleUserExplorerHandler
 
 class MainActivity : AppCompatActivity() {
 
@@ -44,26 +50,23 @@ class MainActivity : AppCompatActivity() {
         Log.i("HackleSdk", "##### onResume")
     }
 
+    @SuppressLint("SetTextI18n")
+    @RequiresApi(Build.VERSION_CODES.R)
     override fun onCreate(savedInstanceState: Bundle?) {
         userService = UserService(this)
         super.onCreate(savedInstanceState)
         setContentView(R.layout.activity_main)
 
-//        (applicationContext as? Application)?.registerActivityLifecycleCallbacks(TestCallback())
-
         val config = HackleConfig.builder()
-//            .eventUri(eventUri)
-//            .sdkUri(sdkUri)
-//            .monitoringUri(monitoringUri)
-//            .logLevel(Log.DEBUG)
-//            .pollingIntervalMillis(10000)
-//            .sessionTimeoutMillis(10000)
-//            .add("\$disable_inappmessage", "true")
+            //.eventUri(eventUri)
+            //.sdkUri(sdkUri)
+            //.monitoringUri(monitoringUri)
+            .logLevel(Log.DEBUG)
+            .mode(HackleAppMode.NATIVE)
             .build()
 
         HackleApp.initializeApp(this, sdkKey, config) {
             findViewById<TextView>(R.id.sdk_status).also { it.text = "INITIALIZED" }
-            Hackle.app.showUserExplorer()
         }
 
         Hackle.app.updatePushSubscriptionStatus(HacklePushSubscriptionStatus.SUBSCRIBED)
@@ -98,11 +101,9 @@ class MainActivity : AppCompatActivity() {
         })
 
         findViewById<TextView>(R.id.sdk_status).setOnClickListener {
-//            startActivity(Intent(this, WebViewActivity::class.java))
-            startActivity(Intent(this, SubActivity::class.java))
+            Hackle.app.showUserExplorer()
         }
 
-        Hackle.app.showUserExplorer(this)
         findViewById<Button>(R.id.ab_text_btn).setOnClickListener {
             longOrNull(R.id.experiment_key)?.let { experimentKey ->
                 if (isChecked(R.id.experiment_with_user)) {
@@ -145,6 +146,15 @@ class MainActivity : AppCompatActivity() {
             }
         }
 
+        findViewById<EditText>(R.id.event_key).setOnKeyListener { _, keyCode, event ->
+            if (event.action == android.view.KeyEvent.ACTION_DOWN && keyCode == android.view.KeyEvent.KEYCODE_ENTER) {
+                findViewById<Button>(R.id.track_btn).performClick()
+                true
+            } else {
+                false
+            }
+        }
+
         findViewById<Button>(R.id.track_btn).setOnClickListener {
             textOrNull(R.id.event_key)?.let { eventKey ->
                 if (isChecked(R.id.track_with_user)) {
@@ -184,11 +194,6 @@ class MainActivity : AppCompatActivity() {
         }
 
 
-//        ArrayAdapter(this, )
-//        findViewById<Spinner>(R.id.hackle_spinner).apply {
-//
-//        }
-
         findViewById<Button>(R.id.pushSubscription_btn).setOnClickListener {
             Hackle.app.updatePushSubscriptionStatus(HacklePushSubscriptionStatus.SUBSCRIBED)
         }
@@ -198,7 +203,14 @@ class MainActivity : AppCompatActivity() {
         }
 
         findViewById<Button>(R.id.secondPage_btn).setOnClickListener {
-            startActivity(Intent(this, SecondPageActivity::class.java))
+            startActivity(Intent(this, WebViewActivity::class.java))
+        }
+
+        ViewCompat.setOnApplyWindowInsetsListener(findViewById(R.id.content)) { v, insets ->
+            val imeInsets = insets.getInsets(WindowInsetsCompat.Type.ime())
+            val bottomPadding = imeInsets.bottom
+            v.setPadding(0, 0, 0, bottomPadding)
+            insets
         }
     }
 
@@ -209,11 +221,5 @@ class MainActivity : AppCompatActivity() {
             }
         }
 
-    }
-
-    val close = if (1 > 2) {
-        "1"
-    } else {
-        null
     }
 }

--- a/TesterApp/src/main/java/io/hackle/android/sdk/tester/MainActivity.kt
+++ b/TesterApp/src/main/java/io/hackle/android/sdk/tester/MainActivity.kt
@@ -208,8 +208,8 @@ class MainActivity : AppCompatActivity() {
 
         ViewCompat.setOnApplyWindowInsetsListener(findViewById(R.id.content)) { v, insets ->
             val imeInsets = insets.getInsets(WindowInsetsCompat.Type.ime())
-            val bottomPadding = imeInsets.bottom
-            v.setPadding(0, 0, 0, bottomPadding)
+            val systemBarInsets = insets.getInsets(WindowInsetsCompat.Type.systemBars())
+            v.setPadding(10, systemBarInsets.top, 10, imeInsets.bottom)
             insets
         }
     }

--- a/TesterApp/src/main/java/io/hackle/android/sdk/tester/WebViewActivity.kt
+++ b/TesterApp/src/main/java/io/hackle/android/sdk/tester/WebViewActivity.kt
@@ -1,14 +1,17 @@
 package io.hackle.android.sdk.tester
 
+import android.annotation.SuppressLint
 import android.os.Bundle
 import android.webkit.WebChromeClient
 import android.webkit.WebView
 import android.webkit.WebViewClient
 import androidx.appcompat.app.AppCompatActivity
+import io.hackle.android.HackleApp
 
 class WebViewActivity : AppCompatActivity() {
     private lateinit var webView: WebView
 
+    @SuppressLint("NewApi")
     override fun onCreate(savedInstanceState: Bundle?) {
         super.onCreate(savedInstanceState)
         setContentView(R.layout.activity_webview)
@@ -26,7 +29,7 @@ class WebViewActivity : AppCompatActivity() {
         webView.settings.setSupportMultipleWindows(true)
         webView.settings.domStorageEnabled = true
         WebView.setWebContentsDebuggingEnabled(true)
-
-        webView.loadUrl("file:///android_asset/sample.html")
+        HackleApp.getInstance().setWebViewBridge(webView)
+        webView.loadUrl("")
     }
 }

--- a/TesterApp/src/main/res/layout/activity_main.xml
+++ b/TesterApp/src/main/res/layout/activity_main.xml
@@ -1,6 +1,7 @@
 <?xml version="1.0" encoding="utf-8"?>
 <LinearLayout xmlns:android="http://schemas.android.com/apk/res/android"
     xmlns:tools="http://schemas.android.com/tools"
+    android:id="@+id/content"
     android:layout_width="match_parent"
     android:layout_height="match_parent"
     android:orientation="vertical"
@@ -10,6 +11,7 @@
     <ScrollView
         android:layout_width="match_parent"
         android:layout_height="wrap_content">
+
         <LinearLayout
             android:layout_width="match_parent"
             android:layout_height="wrap_content"
@@ -307,8 +309,7 @@
             <Spinner
                 android:id="@+id/hackle_spinner"
                 android:layout_width="wrap_content"
-                android:layout_height="wrap_content">
-            </Spinner>
+                android:layout_height="wrap_content"></Spinner>
 
             <LinearLayout
                 android:layout_width="wrap_content"
@@ -320,16 +321,16 @@
                     android:id="@+id/pushSubscription_btn"
                     android:layout_width="match_parent"
                     android:layout_height="wrap_content"
-                    android:text="@string/push_subscribed"
-                    android:layout_weight="1"/>
+                    android:layout_weight="1"
+                    android:text="@string/push_subscribed" />
 
                 <Button
                     android:id="@+id/pushUnsubscription_btn"
                     android:layout_width="match_parent"
                     android:layout_height="wrap_content"
-                    android:text="@string/push_unsubscribed"
+                    android:layout_marginLeft="16dp"
                     android:layout_weight="1"
-                    android:layout_marginLeft="16dp"/>
+                    android:text="@string/push_unsubscribed" />
 
             </LinearLayout>
 

--- a/TesterApp/src/main/res/values-v23/themes.xml
+++ b/TesterApp/src/main/res/values-v23/themes.xml
@@ -1,5 +1,5 @@
+<?xml version="1.0" encoding="utf-8"?>
 <resources xmlns:tools="http://schemas.android.com/tools">
-    <!-- Base application theme. -->
     <style name="Theme.Androidsdktester" parent="Theme.MaterialComponents.DayNight.DarkActionBar">
         <!-- Primary brand color. -->
         <item name="colorPrimary">@color/purple_500</item>
@@ -10,15 +10,9 @@
         <item name="colorSecondaryVariant">@color/teal_700</item>
         <item name="colorOnSecondary">@color/black</item>
         <!-- Status bar color. -->
-        <item name="android:statusBarColor" tools:targetApi="l">?attr/colorPrimaryVariant</item>
+        <item name="android:statusBarColor" tools:targetApi="l">?attr/colorPrimaryVariant
+        </item>
+        <item name="android:windowLightStatusBar">true</item>
         <!-- Customize your theme here. -->
     </style>
-    <style name="Theme.Androidsdktester.NoActionBar">
-        <item name="windowActionBar">false</item>
-        <item name="windowNoTitle">true</item>
-    </style>
-
-    <style name="Theme.Androidsdktester.AppBarOverlay" parent="ThemeOverlay.AppCompat.Dark.ActionBar" />
-
-    <style name="Theme.Androidsdktester.PopupOverlay" parent="ThemeOverlay.AppCompat.Light" />
 </resources>

--- a/TesterApp/src/main/res/values-v27/themes.xml
+++ b/TesterApp/src/main/res/values-v27/themes.xml
@@ -1,5 +1,5 @@
+<?xml version="1.0" encoding="utf-8"?>
 <resources xmlns:tools="http://schemas.android.com/tools">
-    <!-- Base application theme. -->
     <style name="Theme.Androidsdktester" parent="Theme.MaterialComponents.DayNight.DarkActionBar">
         <!-- Primary brand color. -->
         <item name="colorPrimary">@color/purple_500</item>
@@ -10,15 +10,10 @@
         <item name="colorSecondaryVariant">@color/teal_700</item>
         <item name="colorOnSecondary">@color/black</item>
         <!-- Status bar color. -->
-        <item name="android:statusBarColor" tools:targetApi="l">?attr/colorPrimaryVariant</item>
+        <item name="android:statusBarColor" tools:targetApi="l">?attr/colorPrimaryVariant
+        </item>
+        <item name="android:windowLightStatusBar">true</item>
+        <item name="android:windowLightNavigationBar">true</item>
         <!-- Customize your theme here. -->
     </style>
-    <style name="Theme.Androidsdktester.NoActionBar">
-        <item name="windowActionBar">false</item>
-        <item name="windowNoTitle">true</item>
-    </style>
-
-    <style name="Theme.Androidsdktester.AppBarOverlay" parent="ThemeOverlay.AppCompat.Dark.ActionBar" />
-
-    <style name="Theme.Androidsdktester.PopupOverlay" parent="ThemeOverlay.AppCompat.Light" />
 </resources>

--- a/hackle-android-sdk/src/main/java/io/hackle/android/ui/inappmessage/InAppMessageControllerFactory.kt
+++ b/hackle-android-sdk/src/main/java/io/hackle/android/ui/inappmessage/InAppMessageControllerFactory.kt
@@ -36,7 +36,7 @@ internal class InAppMessageControllerFactory(
         val controller = InAppMessageViewController(view, context, ui)
         view.setController(controller)
 
-        // add bottom margin when enableEdgeToEdge
+        // add margin when enableEdgeToEdge
         // ref. https://developer.android.com/develop/ui/views/layout/edge-to-edge#system-bars-insets
         if(controller.context.message.layout.displayType == BANNER || controller.context.message.layout.displayType == BOTTOM_SHEET) {
             ViewCompat.setOnApplyWindowInsetsListener(view) { v, windowInsets ->

--- a/hackle-android-sdk/src/main/java/io/hackle/android/ui/inappmessage/InAppMessageControllerFactory.kt
+++ b/hackle-android-sdk/src/main/java/io/hackle/android/ui/inappmessage/InAppMessageControllerFactory.kt
@@ -2,10 +2,10 @@ package io.hackle.android.ui.inappmessage
 
 import android.annotation.SuppressLint
 import android.app.Activity
-import android.os.Build
+import android.view.View
 import android.view.ViewGroup
-import android.view.WindowInsets
 import androidx.core.view.ViewCompat
+import androidx.core.view.WindowInsetsCompat
 import androidx.core.view.updateLayoutParams
 import io.hackle.android.internal.inappmessage.presentation.InAppMessagePresentationContext
 import io.hackle.android.ui.inappmessage.layout.view.InAppMessageViewController
@@ -36,64 +36,34 @@ internal class InAppMessageControllerFactory(
         val controller = InAppMessageViewController(view, context, ui)
         view.setController(controller)
 
-        // add margin when enableEdgeToEdge
-        // ref. https://developer.android.com/develop/ui/views/layout/edge-to-edge#system-bars-insets
         if(controller.context.message.layout.displayType == BANNER || controller.context.message.layout.displayType == BOTTOM_SHEET) {
-            ViewCompat.setOnApplyWindowInsetsListener(view) { v, windowInsets ->
-                val inAppMessageAlignment = controller.context.message.layout.alignment?.vertical
-
-                if(inAppMessageAlignment == InAppMessage.Message.Alignment.Vertical.TOP) {
-                    v.updateLayoutParams<ViewGroup.MarginLayoutParams> {
-                        val statusBarHeight = getStatusBarHeight(activity)
-                        topMargin += statusBarHeight
-                    }
-                } else if(inAppMessageAlignment == InAppMessage.Message.Alignment.Vertical.BOTTOM) {
-                    v.updateLayoutParams<ViewGroup.MarginLayoutParams> {
-                        val navigationBarHeight = getNavigationBarHeight(activity)
-                        bottomMargin += navigationBarHeight
-                    }
-                }
-                // 마진 적용 후 리스너 해제
-                ViewCompat.setOnApplyWindowInsetsListener(v, null)
-
-                windowInsets
-            }
+            setOnApplyWindowInsetsListener(view, controller)
         }
 
         view.configure()
         return controller
     }
 
-    @SuppressLint("InternalInsetResource")
-    private fun getNavigationBarHeight(activity: Activity): Int {
-        if (Build.VERSION.SDK_INT >= Build.VERSION_CODES.R) {
-            val insets = activity.window.decorView.rootWindowInsets
-            return insets?.getInsets(WindowInsets.Type.navigationBars())?.bottom ?: 0
-        } else {
-            val resourceId =
-                activity.resources.getIdentifier("navigation_bar_height", "dimen", "android")
-            return if (resourceId > 0) {
-                activity.resources.getDimensionPixelSize(resourceId)
-            } else {
-                0
-            }
-        }
-    }
+    // add margin when enableEdgeToEdge
+    // ref. https://developer.android.com/develop/ui/views/layout/edge-to-edge#system-bars-insets
+    @SuppressLint("RestrictedApi")
+    private fun setOnApplyWindowInsetsListener(view: View, controller: InAppMessageController) {
+        ViewCompat.setOnApplyWindowInsetsListener(view) { v, windowInsets ->
+            val inAppMessageAlignment = controller.context.message.layout.alignment?.vertical
 
-    @SuppressLint("InternalInsetResource")
-    private fun getStatusBarHeight(activity: Activity): Int {
-        return if (Build.VERSION.SDK_INT >= Build.VERSION_CODES.R) {
-            val insets = activity.window.decorView.rootWindowInsets
-            insets?.getInsets(WindowInsets.Type.statusBars())?.top ?: 0
-        } else {
-            val resourceId = activity.resources.getIdentifier(
-                "status_bar_height", "dimen", "android"
-            )
-            if (resourceId > 0) {
-                activity.resources.getDimensionPixelSize(resourceId)
-            } else {
-                0
+            if(inAppMessageAlignment == InAppMessage.Message.Alignment.Vertical.TOP) {
+                v.updateLayoutParams<ViewGroup.MarginLayoutParams> {
+                    topMargin += windowInsets.systemWindowInsetTop
+                }
+            } else if(inAppMessageAlignment == InAppMessage.Message.Alignment.Vertical.BOTTOM) {
+                v.updateLayoutParams<ViewGroup.MarginLayoutParams> {
+                    bottomMargin += windowInsets.systemWindowInsetBottom
+                }
             }
+            // 마진 적용 후 리스너 해제
+            ViewCompat.setOnApplyWindowInsetsListener(v, null)
+
+            WindowInsetsCompat.CONSUMED
         }
     }
 }

--- a/hackle-android-sdk/src/main/java/io/hackle/android/ui/inappmessage/InAppMessageControllerFactory.kt
+++ b/hackle-android-sdk/src/main/java/io/hackle/android/ui/inappmessage/InAppMessageControllerFactory.kt
@@ -53,8 +53,8 @@ internal class InAppMessageControllerFactory(
                         bottomMargin += navigationBarHeight
                     }
                 }
-
-
+                // 마진 적용 후 리스너 해제
+                ViewCompat.setOnApplyWindowInsetsListener(v, null)
 
                 windowInsets
             }

--- a/hackle-android-sdk/src/main/java/io/hackle/android/ui/inappmessage/InAppMessageControllerFactory.kt
+++ b/hackle-android-sdk/src/main/java/io/hackle/android/ui/inappmessage/InAppMessageControllerFactory.kt
@@ -1,18 +1,11 @@
 package io.hackle.android.ui.inappmessage
 
-import android.annotation.SuppressLint
 import android.app.Activity
-import android.os.Build
-import android.view.View
-import android.view.ViewGroup
 import androidx.core.view.ViewCompat
-import androidx.core.view.WindowInsetsCompat
-import androidx.core.view.updateLayoutParams
 import io.hackle.android.internal.inappmessage.presentation.InAppMessagePresentationContext
 import io.hackle.android.ui.inappmessage.layout.view.InAppMessageView
 import io.hackle.android.ui.inappmessage.layout.view.InAppMessageViewController
 import io.hackle.android.ui.inappmessage.layout.view.InAppMessageViewFactory
-import io.hackle.sdk.core.model.InAppMessage
 import io.hackle.sdk.core.model.InAppMessage.DisplayType.*
 
 internal class InAppMessageControllerFactory(
@@ -45,11 +38,10 @@ internal class InAppMessageControllerFactory(
 
     // add margin when enableEdgeToEdge
     // ref. https://developer.android.com/develop/ui/views/layout/edge-to-edge#system-bars-insets
-    @SuppressLint("RestrictedApi")
     private fun setOnApplyWindowInsetsListener(view: InAppMessageView) {
         ViewCompat.setOnApplyWindowInsetsListener(view) { v, windowInsets ->
             (v as? InAppMessageView)?.onApplyWindowInsets(windowInsets)
-            WindowInsetsCompat.CONSUMED
+            windowInsets
         }
     }
 }

--- a/hackle-android-sdk/src/main/java/io/hackle/android/ui/inappmessage/InAppMessageControllerFactory.kt
+++ b/hackle-android-sdk/src/main/java/io/hackle/android/ui/inappmessage/InAppMessageControllerFactory.kt
@@ -2,12 +2,14 @@ package io.hackle.android.ui.inappmessage
 
 import android.annotation.SuppressLint
 import android.app.Activity
+import android.os.Build
 import android.view.View
 import android.view.ViewGroup
 import androidx.core.view.ViewCompat
 import androidx.core.view.WindowInsetsCompat
 import androidx.core.view.updateLayoutParams
 import io.hackle.android.internal.inappmessage.presentation.InAppMessagePresentationContext
+import io.hackle.android.ui.inappmessage.layout.view.InAppMessageView
 import io.hackle.android.ui.inappmessage.layout.view.InAppMessageViewController
 import io.hackle.android.ui.inappmessage.layout.view.InAppMessageViewFactory
 import io.hackle.sdk.core.model.InAppMessage
@@ -35,10 +37,7 @@ internal class InAppMessageControllerFactory(
         val view = viewFactory.create(context, activity)
         val controller = InAppMessageViewController(view, context, ui)
         view.setController(controller)
-
-        if(controller.context.message.layout.displayType == BANNER || controller.context.message.layout.displayType == BOTTOM_SHEET) {
-            setOnApplyWindowInsetsListener(view, controller)
-        }
+        setOnApplyWindowInsetsListener(view)
 
         view.configure()
         return controller
@@ -47,22 +46,9 @@ internal class InAppMessageControllerFactory(
     // add margin when enableEdgeToEdge
     // ref. https://developer.android.com/develop/ui/views/layout/edge-to-edge#system-bars-insets
     @SuppressLint("RestrictedApi")
-    private fun setOnApplyWindowInsetsListener(view: View, controller: InAppMessageController) {
+    private fun setOnApplyWindowInsetsListener(view: InAppMessageView) {
         ViewCompat.setOnApplyWindowInsetsListener(view) { v, windowInsets ->
-            val inAppMessageAlignment = controller.context.message.layout.alignment?.vertical
-
-            if(inAppMessageAlignment == InAppMessage.Message.Alignment.Vertical.TOP) {
-                v.updateLayoutParams<ViewGroup.MarginLayoutParams> {
-                    topMargin += windowInsets.systemWindowInsetTop
-                }
-            } else if(inAppMessageAlignment == InAppMessage.Message.Alignment.Vertical.BOTTOM) {
-                v.updateLayoutParams<ViewGroup.MarginLayoutParams> {
-                    bottomMargin += windowInsets.systemWindowInsetBottom
-                }
-            }
-            // 마진 적용 후 리스너 해제
-            ViewCompat.setOnApplyWindowInsetsListener(v, null)
-
+            (v as? InAppMessageView)?.onApplyWindowInsets(windowInsets)
             WindowInsetsCompat.CONSUMED
         }
     }

--- a/hackle-android-sdk/src/main/java/io/hackle/android/ui/inappmessage/layout/view/InAppMessageView.kt
+++ b/hackle-android-sdk/src/main/java/io/hackle/android/ui/inappmessage/layout/view/InAppMessageView.kt
@@ -66,7 +66,8 @@ internal abstract class InAppMessageView @JvmOverloads constructor(
      * [WindowInsetsCompat] object. This contains information about areas such as
      * system bars that should not overlap with the content.
      */
-    open fun onApplyWindowInsets(insets: WindowInsetsCompat) {
+    open fun onApplyWindowInsets(insets: WindowInsetsCompat)
+    {
         // nothing to do
     }
 }

--- a/hackle-android-sdk/src/main/java/io/hackle/android/ui/inappmessage/layout/view/InAppMessageView.kt
+++ b/hackle-android-sdk/src/main/java/io/hackle/android/ui/inappmessage/layout/view/InAppMessageView.kt
@@ -66,8 +66,7 @@ internal abstract class InAppMessageView @JvmOverloads constructor(
      * [WindowInsetsCompat] object. This contains information about areas such as
      * system bars that should not overlap with the content.
      */
-    open fun onApplyWindowInsets(insets: WindowInsetsCompat)
-    {
+    open fun onApplyWindowInsets(insets: WindowInsetsCompat) {
         // nothing to do
     }
 }

--- a/hackle-android-sdk/src/main/java/io/hackle/android/ui/inappmessage/layout/view/InAppMessageView.kt
+++ b/hackle-android-sdk/src/main/java/io/hackle/android/ui/inappmessage/layout/view/InAppMessageView.kt
@@ -4,7 +4,10 @@ import android.app.Activity
 import android.content.Context
 import android.util.AttributeSet
 import android.view.View.OnClickListener
+import android.view.WindowInsets
 import android.widget.RelativeLayout
+import androidx.core.graphics.Insets
+import androidx.core.view.WindowInsetsCompat
 import io.hackle.android.internal.inappmessage.presentation.InAppMessagePresentationContext
 import io.hackle.android.ui.inappmessage.InAppMessageLifecycle
 import io.hackle.android.ui.inappmessage.event.InAppMessageEvent
@@ -53,6 +56,20 @@ internal abstract class InAppMessageView @JvmOverloads constructor(
     abstract val closeAnimator: InAppMessageAnimator?
 
     abstract fun configure()
+
+    /**
+     * Called to apply window insets to the view.
+     * This function is a placeholder and does not perform any operation by default.
+     * Subclasses can override this method to customize how window insets are handled.
+     *
+     * @param insets The window insets provided by the system, encapsulated in a
+     * [WindowInsetsCompat] object. This contains information about areas such as
+     * system bars that should not overlap with the content.
+     */
+    open fun onApplyWindowInsets(insets: WindowInsetsCompat)
+    {
+        // nothing to do
+    }
 }
 
 internal fun InAppMessageView.createCloseListener(): OnClickListener {

--- a/hackle-android-sdk/src/main/java/io/hackle/android/ui/inappmessage/layout/view/InAppMessageViewController.kt
+++ b/hackle-android-sdk/src/main/java/io/hackle/android/ui/inappmessage/layout/view/InAppMessageViewController.kt
@@ -3,8 +3,11 @@ package io.hackle.android.ui.inappmessage.layout.view
 import android.app.Activity
 import android.content.pm.ActivityInfo
 import android.os.Build
+import android.view.View
 import android.view.ViewGroup
 import androidx.core.view.ViewCompat
+import androidx.core.view.WindowInsetsCompat
+import androidx.core.view.updateLayoutParams
 import io.hackle.android.internal.inappmessage.presentation.InAppMessagePresentationContext
 import io.hackle.android.ui.core.setActivityRequestedOrientation
 import io.hackle.android.ui.inappmessage.*
@@ -13,6 +16,7 @@ import io.hackle.android.ui.inappmessage.event.InAppMessageEvent
 import io.hackle.android.ui.inappmessage.layout.InAppMessageAnimator
 import io.hackle.android.ui.inappmessage.layout.InAppMessageLayout.State
 import io.hackle.sdk.core.internal.log.Logger
+import io.hackle.sdk.core.model.InAppMessage
 import java.util.concurrent.atomic.AtomicReference
 
 
@@ -27,6 +31,12 @@ internal class InAppMessageViewController(
 
     private val _state = AtomicReference(State.CLOSED)
     val state: State get() = _state.get()
+
+    init {
+        if(context.message.layout.displayType == InAppMessage.DisplayType.BOTTOM_SHEET) {
+
+        }
+    }
 
     override fun open(activity: Activity) {
         if (!_state.compareAndSet(State.CLOSED, State.OPENED)) {

--- a/hackle-android-sdk/src/main/java/io/hackle/android/ui/inappmessage/layout/view/InAppMessageViewController.kt
+++ b/hackle-android-sdk/src/main/java/io/hackle/android/ui/inappmessage/layout/view/InAppMessageViewController.kt
@@ -32,12 +32,6 @@ internal class InAppMessageViewController(
     private val _state = AtomicReference(State.CLOSED)
     val state: State get() = _state.get()
 
-    init {
-        if(context.message.layout.displayType == InAppMessage.DisplayType.BOTTOM_SHEET) {
-
-        }
-    }
-
     override fun open(activity: Activity) {
         if (!_state.compareAndSet(State.CLOSED, State.OPENED)) {
             log.debug { "InAppMessage is already open (key=${context.inAppMessage.key})" }

--- a/hackle-android-sdk/src/main/java/io/hackle/android/ui/inappmessage/layout/view/InAppMessageViewController.kt
+++ b/hackle-android-sdk/src/main/java/io/hackle/android/ui/inappmessage/layout/view/InAppMessageViewController.kt
@@ -32,6 +32,12 @@ internal class InAppMessageViewController(
     private val _state = AtomicReference(State.CLOSED)
     val state: State get() = _state.get()
 
+    init {
+        if(context.message.layout.displayType == InAppMessage.DisplayType.BOTTOM_SHEET) {
+
+        }
+    }
+
     override fun open(activity: Activity) {
         if (!_state.compareAndSet(State.CLOSED, State.OPENED)) {
             log.debug { "InAppMessage is already open (key=${context.inAppMessage.key})" }

--- a/hackle-android-sdk/src/main/java/io/hackle/android/ui/inappmessage/layout/view/banner/InAppMessageBannerImageView.kt
+++ b/hackle-android-sdk/src/main/java/io/hackle/android/ui/inappmessage/layout/view/banner/InAppMessageBannerImageView.kt
@@ -78,12 +78,12 @@ internal class InAppMessageBannerImageView @JvmOverloads constructor(
     override fun onApplyWindowInsets(insets: WindowInsetsCompat) {
         val inAppMessageAlignment = controller.context.message.layout.alignment?.vertical
 
-        if(inAppMessageAlignment == InAppMessage.Message.Alignment.Vertical.TOP) {
+        if (inAppMessageAlignment == InAppMessage.Message.Alignment.Vertical.TOP) {
             updateLayoutParams<MarginLayoutParams> {
                 topMargin = this@InAppMessageBannerImageView.topMargin + insets.systemWindowInsetTop
             }
 
-        } else if(inAppMessageAlignment == InAppMessage.Message.Alignment.Vertical.BOTTOM) {
+        } else if (inAppMessageAlignment == InAppMessage.Message.Alignment.Vertical.BOTTOM) {
             updateLayoutParams<MarginLayoutParams> {
                 bottomMargin = this@InAppMessageBannerImageView.bottomMargin + insets.systemWindowInsetBottom
             }

--- a/hackle-android-sdk/src/main/java/io/hackle/android/ui/inappmessage/layout/view/banner/InAppMessageBannerImageView.kt
+++ b/hackle-android-sdk/src/main/java/io/hackle/android/ui/inappmessage/layout/view/banner/InAppMessageBannerImageView.kt
@@ -45,8 +45,16 @@ internal class InAppMessageBannerImageView @JvmOverloads constructor(
     private val messageAlignment: InAppMessage.Message.Alignment get() = requireNotNull(message.layout.alignment) { "Not found Alignment in banner in-app message [${inAppMessage.id}]" }
 
     // Animation
-    override val openAnimator: InAppMessageAnimator get() = InAppMessageAnimator.of(this, Animations.fadeIn(50))
-    override val closeAnimator: InAppMessageAnimator get() = InAppMessageAnimator.of(this, Animations.fadeOut(50))
+    override val openAnimator: InAppMessageAnimator
+        get() = InAppMessageAnimator.of(
+            this,
+            Animations.fadeIn(50)
+        )
+    override val closeAnimator: InAppMessageAnimator
+        get() = InAppMessageAnimator.of(
+            this,
+            Animations.fadeOut(50)
+        )
 
     override fun onMeasure(widthMeasureSpec: Int, heightMeasureSpec: Int) {
         super.onMeasure(widthMeasureSpec, heightMeasureSpec)
@@ -78,14 +86,15 @@ internal class InAppMessageBannerImageView @JvmOverloads constructor(
     override fun onApplyWindowInsets(insets: WindowInsetsCompat) {
         val inAppMessageAlignment = controller.context.message.layout.alignment?.vertical
 
-        if(inAppMessageAlignment == InAppMessage.Message.Alignment.Vertical.TOP) {
+        if (inAppMessageAlignment == InAppMessage.Message.Alignment.Vertical.TOP) {
             updateLayoutParams<MarginLayoutParams> {
                 topMargin = this@InAppMessageBannerImageView.topMargin + insets.systemWindowInsetTop
             }
 
-        } else if(inAppMessageAlignment == InAppMessage.Message.Alignment.Vertical.BOTTOM) {
+        } else if (inAppMessageAlignment == InAppMessage.Message.Alignment.Vertical.BOTTOM) {
             updateLayoutParams<MarginLayoutParams> {
-                bottomMargin = this@InAppMessageBannerImageView.bottomMargin + insets.systemWindowInsetBottom
+                bottomMargin =
+                    this@InAppMessageBannerImageView.bottomMargin + insets.systemWindowInsetBottom
             }
         }
     }

--- a/hackle-android-sdk/src/main/java/io/hackle/android/ui/inappmessage/layout/view/banner/InAppMessageBannerImageView.kt
+++ b/hackle-android-sdk/src/main/java/io/hackle/android/ui/inappmessage/layout/view/banner/InAppMessageBannerImageView.kt
@@ -45,16 +45,8 @@ internal class InAppMessageBannerImageView @JvmOverloads constructor(
     private val messageAlignment: InAppMessage.Message.Alignment get() = requireNotNull(message.layout.alignment) { "Not found Alignment in banner in-app message [${inAppMessage.id}]" }
 
     // Animation
-    override val openAnimator: InAppMessageAnimator
-        get() = InAppMessageAnimator.of(
-            this,
-            Animations.fadeIn(50)
-        )
-    override val closeAnimator: InAppMessageAnimator
-        get() = InAppMessageAnimator.of(
-            this,
-            Animations.fadeOut(50)
-        )
+    override val openAnimator: InAppMessageAnimator get() = InAppMessageAnimator.of(this, Animations.fadeIn(50))
+    override val closeAnimator: InAppMessageAnimator get() = InAppMessageAnimator.of(this, Animations.fadeOut(50))
 
     override fun onMeasure(widthMeasureSpec: Int, heightMeasureSpec: Int) {
         super.onMeasure(widthMeasureSpec, heightMeasureSpec)
@@ -86,15 +78,14 @@ internal class InAppMessageBannerImageView @JvmOverloads constructor(
     override fun onApplyWindowInsets(insets: WindowInsetsCompat) {
         val inAppMessageAlignment = controller.context.message.layout.alignment?.vertical
 
-        if (inAppMessageAlignment == InAppMessage.Message.Alignment.Vertical.TOP) {
+        if(inAppMessageAlignment == InAppMessage.Message.Alignment.Vertical.TOP) {
             updateLayoutParams<MarginLayoutParams> {
                 topMargin = this@InAppMessageBannerImageView.topMargin + insets.systemWindowInsetTop
             }
 
-        } else if (inAppMessageAlignment == InAppMessage.Message.Alignment.Vertical.BOTTOM) {
+        } else if(inAppMessageAlignment == InAppMessage.Message.Alignment.Vertical.BOTTOM) {
             updateLayoutParams<MarginLayoutParams> {
-                bottomMargin =
-                    this@InAppMessageBannerImageView.bottomMargin + insets.systemWindowInsetBottom
+                bottomMargin = this@InAppMessageBannerImageView.bottomMargin + insets.systemWindowInsetBottom
             }
         }
     }

--- a/hackle-android-sdk/src/main/java/io/hackle/android/ui/inappmessage/layout/view/banner/InAppMessageBannerImageView.kt
+++ b/hackle-android-sdk/src/main/java/io/hackle/android/ui/inappmessage/layout/view/banner/InAppMessageBannerImageView.kt
@@ -8,6 +8,8 @@ import android.view.View
 import android.widget.FrameLayout
 import android.widget.FrameLayout.LayoutParams.WRAP_CONTENT
 import android.widget.ImageView.ScaleType.FIT_CENTER
+import androidx.core.view.WindowInsetsCompat
+import androidx.core.view.updateLayoutParams
 import io.hackle.android.R
 import io.hackle.android.ui.core.Animations
 import io.hackle.android.ui.inappmessage.image
@@ -16,6 +18,7 @@ import io.hackle.android.ui.inappmessage.layout.view.InAppMessageCloseButtonView
 import io.hackle.android.ui.inappmessage.layout.view.InAppMessageImageView
 import io.hackle.android.ui.inappmessage.layout.view.InAppMessageImageView.AspectRatio
 import io.hackle.android.ui.inappmessage.layout.view.InAppMessageView
+import io.hackle.android.ui.inappmessage.layout.view.banner.InAppMessageBannerView
 import io.hackle.android.ui.inappmessage.layout.view.createMessageClickListener
 import io.hackle.android.ui.inappmessage.requiredOrientation
 import io.hackle.sdk.core.model.InAppMessage
@@ -69,6 +72,21 @@ internal class InAppMessageBannerImageView @JvmOverloads constructor(
             closeButtonView.configure(this, closeButton)
         } else {
             closeButtonView.visibility = View.GONE
+        }
+    }
+
+    override fun onApplyWindowInsets(insets: WindowInsetsCompat) {
+        val inAppMessageAlignment = controller.context.message.layout.alignment?.vertical
+
+        if(inAppMessageAlignment == InAppMessage.Message.Alignment.Vertical.TOP) {
+            updateLayoutParams<MarginLayoutParams> {
+                topMargin = this@InAppMessageBannerImageView.topMargin + insets.systemWindowInsetTop
+            }
+
+        } else if(inAppMessageAlignment == InAppMessage.Message.Alignment.Vertical.BOTTOM) {
+            updateLayoutParams<MarginLayoutParams> {
+                bottomMargin = this@InAppMessageBannerImageView.bottomMargin + insets.systemWindowInsetBottom
+            }
         }
     }
 

--- a/hackle-android-sdk/src/main/java/io/hackle/android/ui/inappmessage/layout/view/banner/InAppMessageBannerView.kt
+++ b/hackle-android-sdk/src/main/java/io/hackle/android/ui/inappmessage/layout/view/banner/InAppMessageBannerView.kt
@@ -7,9 +7,14 @@ import android.graphics.drawable.Drawable
 import android.util.AttributeSet
 import android.view.Gravity
 import android.view.View
+import android.view.ViewGroup
+import android.view.WindowInsets
 import android.widget.FrameLayout
 import android.widget.FrameLayout.LayoutParams.WRAP_CONTENT
 import android.widget.ImageView.ScaleType.FIT_CENTER
+import androidx.core.view.ViewCompat
+import androidx.core.view.WindowInsetsCompat
+import androidx.core.view.updateLayoutParams
 import io.hackle.android.R
 import io.hackle.android.ui.core.Animations
 import io.hackle.android.ui.core.CornerRadii
@@ -83,7 +88,20 @@ internal class InAppMessageBannerView @JvmOverloads constructor(
         }
     }
 
-    // Configuration
+    override fun onApplyWindowInsets(insets: WindowInsetsCompat) {
+        val inAppMessageAlignment = controller.context.message.layout.alignment?.vertical
+
+        if(inAppMessageAlignment == InAppMessage.Message.Alignment.Vertical.TOP) {
+            updateLayoutParams<MarginLayoutParams> {
+                topMargin = this@InAppMessageBannerView.topMargin + insets.systemWindowInsetTop
+            }
+
+        } else if(inAppMessageAlignment == InAppMessage.Message.Alignment.Vertical.BOTTOM) {
+            updateLayoutParams<MarginLayoutParams> {
+                bottomMargin = this@InAppMessageBannerView.bottomMargin + insets.systemWindowInsetBottom
+            }
+        }
+    }
 
     private val messageLayoutParams: FrameLayout.LayoutParams
         get() {

--- a/hackle-android-sdk/src/main/java/io/hackle/android/ui/inappmessage/layout/view/banner/InAppMessageBannerView.kt
+++ b/hackle-android-sdk/src/main/java/io/hackle/android/ui/inappmessage/layout/view/banner/InAppMessageBannerView.kt
@@ -52,8 +52,16 @@ internal class InAppMessageBannerView @JvmOverloads constructor(
     private val messageText: InAppMessage.Message.Text get() = requireNotNull(message.text) { "Not found Text in banner in-app message [${inAppMessage.id}]" }
 
     // Animation
-    override val openAnimator: InAppMessageAnimator get() = InAppMessageAnimator.of(this, Animations.fadeIn(50))
-    override val closeAnimator: InAppMessageAnimator get() = InAppMessageAnimator.of(this, Animations.fadeOut(50))
+    override val openAnimator: InAppMessageAnimator
+        get() = InAppMessageAnimator.of(
+            this,
+            Animations.fadeIn(50)
+        )
+    override val closeAnimator: InAppMessageAnimator
+        get() = InAppMessageAnimator.of(
+            this,
+            Animations.fadeOut(50)
+        )
 
     override fun onMeasure(widthMeasureSpec: Int, heightMeasureSpec: Int) {
         super.onMeasure(widthMeasureSpec, heightMeasureSpec)
@@ -91,14 +99,15 @@ internal class InAppMessageBannerView @JvmOverloads constructor(
     override fun onApplyWindowInsets(insets: WindowInsetsCompat) {
         val inAppMessageAlignment = controller.context.message.layout.alignment?.vertical
 
-        if(inAppMessageAlignment == InAppMessage.Message.Alignment.Vertical.TOP) {
+        if (inAppMessageAlignment == InAppMessage.Message.Alignment.Vertical.TOP) {
             updateLayoutParams<MarginLayoutParams> {
                 topMargin = this@InAppMessageBannerView.topMargin + insets.systemWindowInsetTop
             }
 
-        } else if(inAppMessageAlignment == InAppMessage.Message.Alignment.Vertical.BOTTOM) {
+        } else if (inAppMessageAlignment == InAppMessage.Message.Alignment.Vertical.BOTTOM) {
             updateLayoutParams<MarginLayoutParams> {
-                bottomMargin = this@InAppMessageBannerView.bottomMargin + insets.systemWindowInsetBottom
+                bottomMargin =
+                    this@InAppMessageBannerView.bottomMargin + insets.systemWindowInsetBottom
             }
         }
     }
@@ -114,7 +123,10 @@ internal class InAppMessageBannerView @JvmOverloads constructor(
 
     private val messageBackground: Drawable
         get() {
-            return Drawables.of(radii = CornerRadii.of(cornerRadius.toFloat()), color = message.backgroundColor)
+            return Drawables.of(
+                radii = CornerRadii.of(cornerRadius.toFloat()),
+                color = message.backgroundColor
+            )
         }
 
     companion object {

--- a/hackle-android-sdk/src/main/java/io/hackle/android/ui/inappmessage/layout/view/banner/InAppMessageBannerView.kt
+++ b/hackle-android-sdk/src/main/java/io/hackle/android/ui/inappmessage/layout/view/banner/InAppMessageBannerView.kt
@@ -91,12 +91,12 @@ internal class InAppMessageBannerView @JvmOverloads constructor(
     override fun onApplyWindowInsets(insets: WindowInsetsCompat) {
         val inAppMessageAlignment = controller.context.message.layout.alignment?.vertical
 
-        if(inAppMessageAlignment == InAppMessage.Message.Alignment.Vertical.TOP) {
+        if (inAppMessageAlignment == InAppMessage.Message.Alignment.Vertical.TOP) {
             updateLayoutParams<MarginLayoutParams> {
                 topMargin = this@InAppMessageBannerView.topMargin + insets.systemWindowInsetTop
             }
 
-        } else if(inAppMessageAlignment == InAppMessage.Message.Alignment.Vertical.BOTTOM) {
+        } else if (inAppMessageAlignment == InAppMessage.Message.Alignment.Vertical.BOTTOM) {
             updateLayoutParams<MarginLayoutParams> {
                 bottomMargin = this@InAppMessageBannerView.bottomMargin + insets.systemWindowInsetBottom
             }

--- a/hackle-android-sdk/src/main/java/io/hackle/android/ui/inappmessage/layout/view/banner/InAppMessageBannerView.kt
+++ b/hackle-android-sdk/src/main/java/io/hackle/android/ui/inappmessage/layout/view/banner/InAppMessageBannerView.kt
@@ -52,16 +52,8 @@ internal class InAppMessageBannerView @JvmOverloads constructor(
     private val messageText: InAppMessage.Message.Text get() = requireNotNull(message.text) { "Not found Text in banner in-app message [${inAppMessage.id}]" }
 
     // Animation
-    override val openAnimator: InAppMessageAnimator
-        get() = InAppMessageAnimator.of(
-            this,
-            Animations.fadeIn(50)
-        )
-    override val closeAnimator: InAppMessageAnimator
-        get() = InAppMessageAnimator.of(
-            this,
-            Animations.fadeOut(50)
-        )
+    override val openAnimator: InAppMessageAnimator get() = InAppMessageAnimator.of(this, Animations.fadeIn(50))
+    override val closeAnimator: InAppMessageAnimator get() = InAppMessageAnimator.of(this, Animations.fadeOut(50))
 
     override fun onMeasure(widthMeasureSpec: Int, heightMeasureSpec: Int) {
         super.onMeasure(widthMeasureSpec, heightMeasureSpec)
@@ -99,15 +91,14 @@ internal class InAppMessageBannerView @JvmOverloads constructor(
     override fun onApplyWindowInsets(insets: WindowInsetsCompat) {
         val inAppMessageAlignment = controller.context.message.layout.alignment?.vertical
 
-        if (inAppMessageAlignment == InAppMessage.Message.Alignment.Vertical.TOP) {
+        if(inAppMessageAlignment == InAppMessage.Message.Alignment.Vertical.TOP) {
             updateLayoutParams<MarginLayoutParams> {
                 topMargin = this@InAppMessageBannerView.topMargin + insets.systemWindowInsetTop
             }
 
-        } else if (inAppMessageAlignment == InAppMessage.Message.Alignment.Vertical.BOTTOM) {
+        } else if(inAppMessageAlignment == InAppMessage.Message.Alignment.Vertical.BOTTOM) {
             updateLayoutParams<MarginLayoutParams> {
-                bottomMargin =
-                    this@InAppMessageBannerView.bottomMargin + insets.systemWindowInsetBottom
+                bottomMargin = this@InAppMessageBannerView.bottomMargin + insets.systemWindowInsetBottom
             }
         }
     }
@@ -123,10 +114,7 @@ internal class InAppMessageBannerView @JvmOverloads constructor(
 
     private val messageBackground: Drawable
         get() {
-            return Drawables.of(
-                radii = CornerRadii.of(cornerRadius.toFloat()),
-                color = message.backgroundColor
-            )
+            return Drawables.of(radii = CornerRadii.of(cornerRadius.toFloat()), color = message.backgroundColor)
         }
 
     companion object {

--- a/hackle-android-sdk/src/main/java/io/hackle/android/ui/inappmessage/layout/view/modal/InAppMessageModalView.kt
+++ b/hackle-android-sdk/src/main/java/io/hackle/android/ui/inappmessage/layout/view/modal/InAppMessageModalView.kt
@@ -54,16 +54,8 @@ internal class InAppMessageModalView @JvmOverloads constructor(
     private val outerButtonViews get() = listOf(leftBottomButtonView, rightBottomButtonView)
 
     // Animation
-    override val openAnimator: InAppMessageAnimator
-        get() = InAppMessageAnimator.of(
-            this,
-            Animations.fadeIn(100)
-        )
-    override val closeAnimator: InAppMessageAnimator
-        get() = InAppMessageAnimator.of(
-            this,
-            Animations.fadeOut(100)
-        )
+    override val openAnimator: InAppMessageAnimator get() = InAppMessageAnimator.of(this, Animations.fadeIn(100))
+    override val closeAnimator: InAppMessageAnimator get() = InAppMessageAnimator.of(this, Animations.fadeOut(100))
 
     // Configuration
     override fun configure() {
@@ -86,8 +78,7 @@ internal class InAppMessageModalView @JvmOverloads constructor(
 
         // Text
         if (configuration.text) {
-            val messageText =
-                requireNotNull(message.text) { "Not found in-app message text [${inAppMessage.id}]" }
+            val messageText = requireNotNull(message.text) { "Not found in-app message text [${inAppMessage.id}]" }
             titleTextView.configure(messageText.title)
             bodyTextView.configure(messageText.body)
         } else {
@@ -113,11 +104,7 @@ internal class InAppMessageModalView @JvmOverloads constructor(
             for (outerButtonView in outerButtonViews) {
                 val outerButton = message.outerButtonOrNull(outerButtonView.alignment)
                 if (outerButton != null) {
-                    outerButtonView.configure(
-                        this,
-                        outerButton.button,
-                        ColorDrawable(Color.TRANSPARENT)
-                    )
+                    outerButtonView.configure(this, outerButton.button, ColorDrawable(Color.TRANSPARENT))
                 } else {
                     outerButtonView.visibility = View.GONE
                 }
@@ -153,27 +140,9 @@ internal class InAppMessageModalView @JvmOverloads constructor(
     private val configuration: Configuration
         get() = when (message.layout.layoutType) {
             NONE -> Configuration(image = false, text = false, button = false, outerButton = false)
-            IMAGE_ONLY -> Configuration(
-                image = true,
-                text = false,
-                button = true,
-                outerButton = false
-            )
-
-            IMAGE_TEXT -> Configuration(
-                image = true,
-                text = true,
-                button = true,
-                outerButton = false
-            )
-
-            TEXT_ONLY -> Configuration(
-                image = false,
-                text = true,
-                button = true,
-                outerButton = false
-            )
-
+            IMAGE_ONLY -> Configuration(image = true, text = false, button = true, outerButton = false)
+            IMAGE_TEXT -> Configuration(image = true, text = true, button = true, outerButton = false)
+            TEXT_ONLY -> Configuration(image = false, text = true, button = true, outerButton = false)
             IMAGE -> Configuration(image = true, text = false, button = false, outerButton = true)
         }
 
@@ -183,10 +152,7 @@ internal class InAppMessageModalView @JvmOverloads constructor(
             return when (message.layout.layoutType) {
                 NONE -> Drawables.transparent()
                 IMAGE -> Drawables.transparent()
-                IMAGE_ONLY, IMAGE_TEXT, TEXT_ONLY -> Drawables.of(
-                    radii = cornerRadii,
-                    color = message.backgroundColor
-                )
+                IMAGE_ONLY, IMAGE_TEXT, TEXT_ONLY -> Drawables.of(radii = cornerRadii, color = message.backgroundColor)
             }
         }
 
@@ -207,10 +173,7 @@ internal class InAppMessageModalView @JvmOverloads constructor(
 
     private val InAppMessage.Message.Button.backgroundDrawable: Drawable
         get() {
-            val background = Drawables.of(
-                radii = CornerRadii.of(buttonCornerRadius.toFloat()),
-                color = backgroundColor
-            )
+            val background = Drawables.of(radii = CornerRadii.of(buttonCornerRadius.toFloat()), color = backgroundColor)
             background.setStroke(buttonStrokeWith, borderColor)
             return background
         }

--- a/hackle-android-sdk/src/main/java/io/hackle/android/ui/inappmessage/layout/view/modal/InAppMessageModalView.kt
+++ b/hackle-android-sdk/src/main/java/io/hackle/android/ui/inappmessage/layout/view/modal/InAppMessageModalView.kt
@@ -54,8 +54,16 @@ internal class InAppMessageModalView @JvmOverloads constructor(
     private val outerButtonViews get() = listOf(leftBottomButtonView, rightBottomButtonView)
 
     // Animation
-    override val openAnimator: InAppMessageAnimator get() = InAppMessageAnimator.of(this, Animations.fadeIn(100))
-    override val closeAnimator: InAppMessageAnimator get() = InAppMessageAnimator.of(this, Animations.fadeOut(100))
+    override val openAnimator: InAppMessageAnimator
+        get() = InAppMessageAnimator.of(
+            this,
+            Animations.fadeIn(100)
+        )
+    override val closeAnimator: InAppMessageAnimator
+        get() = InAppMessageAnimator.of(
+            this,
+            Animations.fadeOut(100)
+        )
 
     // Configuration
     override fun configure() {
@@ -78,7 +86,8 @@ internal class InAppMessageModalView @JvmOverloads constructor(
 
         // Text
         if (configuration.text) {
-            val messageText = requireNotNull(message.text) { "Not found in-app message text [${inAppMessage.id}]" }
+            val messageText =
+                requireNotNull(message.text) { "Not found in-app message text [${inAppMessage.id}]" }
             titleTextView.configure(messageText.title)
             bodyTextView.configure(messageText.body)
         } else {
@@ -104,7 +113,11 @@ internal class InAppMessageModalView @JvmOverloads constructor(
             for (outerButtonView in outerButtonViews) {
                 val outerButton = message.outerButtonOrNull(outerButtonView.alignment)
                 if (outerButton != null) {
-                    outerButtonView.configure(this, outerButton.button, ColorDrawable(Color.TRANSPARENT))
+                    outerButtonView.configure(
+                        this,
+                        outerButton.button,
+                        ColorDrawable(Color.TRANSPARENT)
+                    )
                 } else {
                     outerButtonView.visibility = View.GONE
                 }
@@ -140,9 +153,27 @@ internal class InAppMessageModalView @JvmOverloads constructor(
     private val configuration: Configuration
         get() = when (message.layout.layoutType) {
             NONE -> Configuration(image = false, text = false, button = false, outerButton = false)
-            IMAGE_ONLY -> Configuration(image = true, text = false, button = true, outerButton = false)
-            IMAGE_TEXT -> Configuration(image = true, text = true, button = true, outerButton = false)
-            TEXT_ONLY -> Configuration(image = false, text = true, button = true, outerButton = false)
+            IMAGE_ONLY -> Configuration(
+                image = true,
+                text = false,
+                button = true,
+                outerButton = false
+            )
+
+            IMAGE_TEXT -> Configuration(
+                image = true,
+                text = true,
+                button = true,
+                outerButton = false
+            )
+
+            TEXT_ONLY -> Configuration(
+                image = false,
+                text = true,
+                button = true,
+                outerButton = false
+            )
+
             IMAGE -> Configuration(image = true, text = false, button = false, outerButton = true)
         }
 
@@ -152,7 +183,10 @@ internal class InAppMessageModalView @JvmOverloads constructor(
             return when (message.layout.layoutType) {
                 NONE -> Drawables.transparent()
                 IMAGE -> Drawables.transparent()
-                IMAGE_ONLY, IMAGE_TEXT, TEXT_ONLY -> Drawables.of(radii = cornerRadii, color = message.backgroundColor)
+                IMAGE_ONLY, IMAGE_TEXT, TEXT_ONLY -> Drawables.of(
+                    radii = cornerRadii,
+                    color = message.backgroundColor
+                )
             }
         }
 
@@ -173,7 +207,10 @@ internal class InAppMessageModalView @JvmOverloads constructor(
 
     private val InAppMessage.Message.Button.backgroundDrawable: Drawable
         get() {
-            val background = Drawables.of(radii = CornerRadii.of(buttonCornerRadius.toFloat()), color = backgroundColor)
+            val background = Drawables.of(
+                radii = CornerRadii.of(buttonCornerRadius.toFloat()),
+                color = backgroundColor
+            )
             background.setStroke(buttonStrokeWith, borderColor)
             return background
         }

--- a/hackle-android-sdk/src/main/java/io/hackle/android/ui/inappmessage/layout/view/sheet/InAppMessageBottomSheetView.kt
+++ b/hackle-android-sdk/src/main/java/io/hackle/android/ui/inappmessage/layout/view/sheet/InAppMessageBottomSheetView.kt
@@ -7,6 +7,8 @@ import android.graphics.drawable.Drawable
 import android.util.AttributeSet
 import android.view.View
 import android.widget.RelativeLayout
+import androidx.core.view.WindowInsetsCompat
+import androidx.core.view.updateLayoutParams
 import io.hackle.android.R
 import io.hackle.android.ui.core.Animations
 import io.hackle.android.ui.core.CornerRadii
@@ -86,6 +88,12 @@ internal class InAppMessageBottomSheetView @JvmOverloads constructor(
             closeButtonView.configure(this, closeButton)
         } else {
             closeButtonView.visibility = View.GONE
+        }
+    }
+
+    override fun onApplyWindowInsets(insets: WindowInsetsCompat) {
+        updateLayoutParams<MarginLayoutParams> {
+            bottomMargin = insets.systemWindowInsetBottom
         }
     }
 

--- a/hackle-android-sdk/src/main/java/io/hackle/android/ui/inappmessage/layout/view/sheet/InAppMessageBottomSheetView.kt
+++ b/hackle-android-sdk/src/main/java/io/hackle/android/ui/inappmessage/layout/view/sheet/InAppMessageBottomSheetView.kt
@@ -97,24 +97,10 @@ internal class InAppMessageBottomSheetView @JvmOverloads constructor(
         }
     }
 
-    private val cornerRadii: CornerRadii
-        get() = CornerRadii.of(
-            cornerRadius.toFloat(),
-            cornerRadius.toFloat(),
-            0f,
-            0f
-        )
-    private val messageBackground: Drawable
-        get() = Drawables.of(
-            radii = cornerRadii,
-            color = message.backgroundColor
-        )
+    private val cornerRadii: CornerRadii get() = CornerRadii.of(cornerRadius.toFloat(), cornerRadius.toFloat(), 0f, 0f)
+    private val messageBackground: Drawable get() = Drawables.of(radii = cornerRadii, color = message.backgroundColor)
 
-    private val imageAspectRatio
-        get() = InAppMessageImageView.AspectRatio(
-            width = 300f,
-            height = 200f
-        )
+    private val imageAspectRatio get() = InAppMessageImageView.AspectRatio(width = 300f, height = 200f)
 
     companion object {
         fun create(activity: Activity): InAppMessageBottomSheetView {

--- a/hackle-android-sdk/src/main/java/io/hackle/android/ui/inappmessage/layout/view/sheet/InAppMessageBottomSheetView.kt
+++ b/hackle-android-sdk/src/main/java/io/hackle/android/ui/inappmessage/layout/view/sheet/InAppMessageBottomSheetView.kt
@@ -97,10 +97,24 @@ internal class InAppMessageBottomSheetView @JvmOverloads constructor(
         }
     }
 
-    private val cornerRadii: CornerRadii get() = CornerRadii.of(cornerRadius.toFloat(), cornerRadius.toFloat(), 0f, 0f)
-    private val messageBackground: Drawable get() = Drawables.of(radii = cornerRadii, color = message.backgroundColor)
+    private val cornerRadii: CornerRadii
+        get() = CornerRadii.of(
+            cornerRadius.toFloat(),
+            cornerRadius.toFloat(),
+            0f,
+            0f
+        )
+    private val messageBackground: Drawable
+        get() = Drawables.of(
+            radii = cornerRadii,
+            color = message.backgroundColor
+        )
 
-    private val imageAspectRatio get() = InAppMessageImageView.AspectRatio(width = 300f, height = 200f)
+    private val imageAspectRatio
+        get() = InAppMessageImageView.AspectRatio(
+            width = 300f,
+            height = 200f
+        )
 
     companion object {
         fun create(activity: Activity): InAppMessageBottomSheetView {


### PR DESCRIPTION
## 개요
`enableEdgeToEdge` 가 앱에 적용된 경우 인앱메시지가 시스템 UI에 가려지거나 위치가 바뀌는 현상을 수정하였습니다.
* Android 15 부터 App의 Target SDK를 35로 설정한 경우 `enableEdgeToEdge`가 강제로 적용됩니다.
* `enableEdgeToEdge` 를 적용하지 않은 구버전 안드로이드에는 영향이 없습니다.
* `enableEdgeToEdge` 를 적용한 구버전 안드로이드는 Android 15 와 동일하게 동작합니다.

## 작업내용
### 인앱메시지 BottomSheet가 시스템 UI에 가려지는 현상을 수정했습니다.

| 안드로이드 버전 | 수정 적용 전 | 수정 적용 후 |
| --- | --- | --- | 
| Android 14 | <img src="https://github.com/user-attachments/assets/622829ab-c009-4371-b5b5-292bd28fc9b7" width="200" /> | <img src="https://github.com/user-attachments/assets/57a3a786-5788-4aa8-9edf-b4445eec52e5" width="200" /> |
| Android 15 | <img src="https://github.com/user-attachments/assets/52f370d7-9b81-412f-ae81-48523a0e4caf" width="200" />  | <img src="https://github.com/user-attachments/assets/21f76562-dc59-4748-98d4-5f77ee043eb0" width="200" /> |

### 인앱메시지 Banner가 시스템 UI의 높이 만큼 margin이 수정되는 현상을 수정했습니다.

| Banner 위치 | Android 14 | 수정 적용 전 | 수정 적용 후 |
| --- | --- | --- |  --- |
| Bottom | <img src="https://github.com/user-attachments/assets/f099e49c-e909-4fd3-8954-8a5fb68f691b" width="200"/> | <img src="https://github.com/user-attachments/assets/72fbc55a-46f3-4f49-988a-c4bf1c2b9abf" width="200"/> | <img src="https://github.com/user-attachments/assets/d82397b9-7773-4c13-aa36-f55f1e76a77e" width="200" /> |
| Top | <img src="https://github.com/user-attachments/assets/13fa885e-82e4-4999-81da-c324239980cf" width="200"/> | <img src="https://github.com/user-attachments/assets/f9d3531b-f52e-4bb8-bfef-faf51db27718" width="200"/> | <img src="https://github.com/user-attachments/assets/0b70879e-0b2a-4e84-9e6d-c45db5105949" width="200"/> |

## 참고
- [안드로이드 개발자 문서](https://developer.android.com/develop/ui/views/layout/edge-to-edge)
- 모달은 영향도가 크게 없습니다.
  - 살짝 밑으로 내려옵니다. 
