### PR TITLE
improve publish action

### DIFF
--- a/.github/workflows/publish.yml
+++ b/.github/workflows/publish.yml
@@ -1,19 +1,17 @@
 name: Publish
 
 on:
+  release:
+    types:
+      - prereleased
   workflow_dispatch:
-    inputs:
-      snapshot:
-        type: boolean
-        required: true
-        default: false
-        description: snapshot publish
 
 jobs:
   publish:
     runs-on: ubuntu-22.04
     steps:
       - uses: actions/checkout@v2
+
       - name: Set up JDK 8
         uses: actions/setup-java@v1
         with:
@@ -24,13 +22,27 @@ jobs:
         with:
           gradle-version: 7.2
 
-      - name: Set up Snapshot version
-        if: ${{ inputs.snapshot }}
+      - name: Set up Snapshot version for Workflow Dispatch
+        if: ${{ github.event_name == 'workflow_dispatch'}}
         run: |
           CURRENT_VERSION=$(grep 'sdk_version=' gradle.properties | sed -E 's/sdk_version=([0-9]+\.[0-9]+\.[0-9]+).*/\1/')
           SHORT_SHA=$(git rev-parse --short HEAD)
           SNAPSHOT_VERSION="$CURRENT_VERSION-$SHORT_SHA-SNAPSHOT"
           sed -i "s/sdk_version=.*/sdk_version=$SNAPSHOT_VERSION/" gradle.properties
+
+      - name: Verify sdk_version matches release name
+        if: ${{ github.event_name == 'release' }}
+        run: |
+          SDK_VERSION=$(grep 'sdk_version=' gradle.properties | sed -E 's/sdk_version=([0-9]+\.[0-9]+\.[0-9]+).*/\1/')
+          RELEASE_NAME="${{ github.event.release.name }}"
+          echo "sdk_version: $SDK_VERSION, release.name: $RELEASE_NAME"
+          if [ "$SDK_VERSION" != "$RELEASE_NAME" ]; then
+            echo "Error: sdk_version ($SDK_VERSION) does not match release.name ($RELEASE_NAME)"
+            echo "Ensure that the release name in GitHub matches the sdk_version in gradle.properties."
+            exit 1
+          else
+            echo "sdk_version matches release.name"
+          fi
 
       - name: Set up secrets
         env:


### PR DESCRIPTION
## 개요
아래 사항이 변경됩니다.
- 패키지 배포는 github release의 prereleased를 통해서만 배포됩니다.
- 패키지 배포 시 `릴리즈 명`과 gradle_proerties의 `sdk_version`이 불일치하면 실패합니다.
- `workflow_dispatch`를 통해 수동으로 패키지 배포 시 snapshot으로만 배포됩니다.