### PR TITLE
set current screen

### DIFF
--- a/hackle-android-sdk/src/main/java/io/hackle/android/HackleApp.kt
+++ b/hackle-android-sdk/src/main/java/io/hackle/android/HackleApp.kt
@@ -21,7 +21,7 @@ import io.hackle.android.internal.pii.PIIEventManager
 import io.hackle.android.internal.pii.phonenumber.PhoneNumber
 import io.hackle.android.internal.push.token.PushTokenManager
 import io.hackle.android.internal.remoteconfig.HackleRemoteConfigImpl
-import io.hackle.android.internal.screen.Screen
+import io.hackle.sdk.common.Screen
 import io.hackle.android.internal.screen.ScreenManager
 import io.hackle.android.internal.session.SessionManager
 import io.hackle.android.internal.sync.PollingSynchronizer
@@ -386,8 +386,8 @@ class HackleApp internal constructor(
         )
     }
 
-    fun setCurrentScreen(screenName: String, className: String) {
-        screenManager.setCurrentScreen(Screen(screenName, className), clock.currentMillis())
+    fun setCurrentScreen(screen: Screen) {
+        screenManager.setCurrentScreen(screen, clock.currentMillis())
     }
 
     override fun close() {

--- a/hackle-android-sdk/src/main/java/io/hackle/android/HackleApp.kt
+++ b/hackle-android-sdk/src/main/java/io/hackle/android/HackleApp.kt
@@ -21,6 +21,8 @@ import io.hackle.android.internal.pii.PIIEventManager
 import io.hackle.android.internal.pii.phonenumber.PhoneNumber
 import io.hackle.android.internal.push.token.PushTokenManager
 import io.hackle.android.internal.remoteconfig.HackleRemoteConfigImpl
+import io.hackle.android.internal.screen.Screen
+import io.hackle.android.internal.screen.ScreenManager
 import io.hackle.android.internal.session.SessionManager
 import io.hackle.android.internal.sync.PollingSynchronizer
 import io.hackle.android.internal.user.UserManager
@@ -56,6 +58,7 @@ class HackleApp internal constructor(
     private val userManager: UserManager,
     private val workspaceManager: WorkspaceManager,
     private val sessionManager: SessionManager,
+    private val screenManager: ScreenManager,
     private val eventProcessor: DefaultEventProcessor,
     private val pushTokenManager: PushTokenManager,
     private val notificationManager: NotificationManager,
@@ -381,6 +384,10 @@ class HackleApp internal constructor(
                 callback?.run()
             }
         )
+    }
+
+    fun setCurrentScreen(name: String, className: String) {
+        screenManager.setCurrentScreen(Screen.from(name, className), clock.currentMillis())
     }
 
     override fun close() {

--- a/hackle-android-sdk/src/main/java/io/hackle/android/HackleApp.kt
+++ b/hackle-android-sdk/src/main/java/io/hackle/android/HackleApp.kt
@@ -387,7 +387,7 @@ class HackleApp internal constructor(
     }
 
     fun setCurrentScreen(screenName: String, className: String) {
-        screenManager.setCurrentScreen(Screen.from(screenName, className), clock.currentMillis())
+        screenManager.setCurrentScreen(Screen(screenName, className), clock.currentMillis())
     }
 
     override fun close() {

--- a/hackle-android-sdk/src/main/java/io/hackle/android/HackleApp.kt
+++ b/hackle-android-sdk/src/main/java/io/hackle/android/HackleApp.kt
@@ -386,8 +386,8 @@ class HackleApp internal constructor(
         )
     }
 
-    fun setCurrentScreen(name: String, className: String) {
-        screenManager.setCurrentScreen(Screen.from(name, className), clock.currentMillis())
+    fun setCurrentScreen(screenName: String, className: String) {
+        screenManager.setCurrentScreen(Screen.from(screenName, className), clock.currentMillis())
     }
 
     override fun close() {

--- a/hackle-android-sdk/src/main/java/io/hackle/android/HackleApps.kt
+++ b/hackle-android-sdk/src/main/java/io/hackle/android/HackleApps.kt
@@ -429,6 +429,7 @@ internal object HackleApps {
             userManager = userManager,
             workspaceManager = workspaceManager,
             sessionManager = sessionManager,
+            screenManager = screenManager,
             eventProcessor = eventProcessor,
             pushTokenManager = pushTokenManager,
             notificationManager = notificationManager,

--- a/hackle-android-sdk/src/main/java/io/hackle/android/internal/bridge/HackleBridge.kt
+++ b/hackle-android-sdk/src/main/java/io/hackle/android/internal/bridge/HackleBridge.kt
@@ -372,7 +372,7 @@ internal class HackleBridge(val app: HackleApp) {
         if (parameters["screenName"] is String && parameters["className"] is String) {
             val screenName = parameters["screenName"] as String
             val className = parameters["className"] as String
-            app.setCurrentScreen(screenName, className)
+            app.setCurrentScreen(Screen(screenName, className))
         } else {
             throw IllegalArgumentException("Valid parameter must be provided.")
         }

--- a/hackle-android-sdk/src/main/java/io/hackle/android/internal/bridge/HackleBridge.kt
+++ b/hackle-android-sdk/src/main/java/io/hackle/android/internal/bridge/HackleBridge.kt
@@ -99,6 +99,11 @@ internal class HackleBridge(val app: HackleApp) {
                 BridgeResponse.success(data)
             }
 
+            SET_CURRENT_SCREEN -> {
+                setCurrentScreen(parameters)
+                BridgeResponse.success()
+            }
+
             SHOW_USER_EXPLORER -> {
                 app.showUserExplorer()
                 BridgeResponse.success()
@@ -360,6 +365,16 @@ internal class HackleBridge(val app: HackleApp) {
             else -> {
                 throw IllegalArgumentException("Valid parameter must be provided.")
             }
+        }
+    }
+
+    private fun setCurrentScreen(parameters: Map<String, Any>) {
+        if (parameters["screenName"] is String && parameters["className"] is String) {
+            val screenName = parameters["screenName"] as String
+            val className = parameters["className"] as String
+            app.setCurrentScreen(screenName, className)
+        } else {
+            throw IllegalArgumentException("Valid parameter must be provided.")
         }
     }
 }

--- a/hackle-android-sdk/src/main/java/io/hackle/android/internal/bridge/model/BridgeInvocation.kt
+++ b/hackle-android-sdk/src/main/java/io/hackle/android/internal/bridge/model/BridgeInvocation.kt
@@ -21,6 +21,7 @@ internal class BridgeInvocation(string: String) {
         FEATURE_FLAG_DETAIL("featureFlagDetail"),
         TRACK("track"),
         REMOTE_CONFIG("remoteConfig"),
+        SET_CURRENT_SCREEN("setCurrentScreen"),
         SHOW_USER_EXPLORER("showUserExplorer"),
         HIDE_USER_EXPLORER("hideUserExplorer");
 

--- a/hackle-android-sdk/src/main/java/io/hackle/android/internal/engagement/Engagement.kt
+++ b/hackle-android-sdk/src/main/java/io/hackle/android/internal/engagement/Engagement.kt
@@ -1,6 +1,6 @@
 package io.hackle.android.internal.engagement
 
-import io.hackle.android.internal.screen.Screen
+import io.hackle.sdk.common.Screen
 
 internal data class Engagement(
     val screen: Screen,

--- a/hackle-android-sdk/src/main/java/io/hackle/android/internal/engagement/EngagementManager.kt
+++ b/hackle-android-sdk/src/main/java/io/hackle/android/internal/engagement/EngagementManager.kt
@@ -5,7 +5,7 @@ import io.hackle.android.internal.core.listener.ApplicationListenerRegistry
 import io.hackle.android.internal.lifecycle.Lifecycle
 import io.hackle.android.internal.lifecycle.Lifecycle.*
 import io.hackle.android.internal.lifecycle.LifecycleListener
-import io.hackle.android.internal.screen.Screen
+import io.hackle.sdk.common.Screen
 import io.hackle.android.internal.screen.ScreenListener
 import io.hackle.android.internal.screen.ScreenManager
 import io.hackle.android.internal.user.UserManager

--- a/hackle-android-sdk/src/main/java/io/hackle/android/internal/event/DefaultEventProcessor.kt
+++ b/hackle-android-sdk/src/main/java/io/hackle/android/internal/event/DefaultEventProcessor.kt
@@ -9,8 +9,6 @@ import io.hackle.android.internal.lifecycle.AppState.FOREGROUND
 import io.hackle.android.internal.lifecycle.AppStateListener
 import io.hackle.android.internal.lifecycle.AppStateManager
 import io.hackle.android.internal.push.PushEventTracker
-import io.hackle.android.internal.screen.ScreenManager
-import io.hackle.android.internal.screen.ScreenUserEventDecorator
 import io.hackle.android.internal.session.SessionEventTracker
 import io.hackle.android.internal.session.SessionManager
 import io.hackle.android.internal.user.UserManager

--- a/hackle-android-sdk/src/main/java/io/hackle/android/internal/screen/Screen.kt
+++ b/hackle-android-sdk/src/main/java/io/hackle/android/internal/screen/Screen.kt
@@ -12,5 +12,9 @@ internal data class Screen(
             val name = activity::class.java.simpleName
             return Screen(name, name)
         }
+
+        fun from(name: String, className: String): Screen {
+            return Screen(name, className)
+        }
     }
 }

--- a/hackle-android-sdk/src/main/java/io/hackle/android/internal/screen/Screen.kt
+++ b/hackle-android-sdk/src/main/java/io/hackle/android/internal/screen/Screen.kt
@@ -12,9 +12,5 @@ internal data class Screen(
             val name = activity::class.java.simpleName
             return Screen(name, name)
         }
-
-        fun from(name: String, className: String): Screen {
-            return Screen(name, className)
-        }
     }
 }

--- a/hackle-android-sdk/src/main/java/io/hackle/android/internal/screen/ScreenEventTracker.kt
+++ b/hackle-android-sdk/src/main/java/io/hackle/android/internal/screen/ScreenEventTracker.kt
@@ -2,6 +2,7 @@ package io.hackle.android.internal.screen
 
 import io.hackle.android.internal.user.UserManager
 import io.hackle.sdk.common.Event
+import io.hackle.sdk.common.Screen
 import io.hackle.sdk.common.User
 import io.hackle.sdk.core.HackleCore
 

--- a/hackle-android-sdk/src/main/java/io/hackle/android/internal/screen/ScreenListener.kt
+++ b/hackle-android-sdk/src/main/java/io/hackle/android/internal/screen/ScreenListener.kt
@@ -1,6 +1,7 @@
 package io.hackle.android.internal.screen
 
 import io.hackle.android.internal.core.listener.ApplicationListener
+import io.hackle.sdk.common.Screen
 import io.hackle.sdk.common.User
 
 internal interface ScreenListener : ApplicationListener {

--- a/hackle-android-sdk/src/main/java/io/hackle/android/internal/screen/ScreenManager.kt
+++ b/hackle-android-sdk/src/main/java/io/hackle/android/internal/screen/ScreenManager.kt
@@ -8,6 +8,7 @@ import io.hackle.android.internal.lifecycle.Lifecycle.*
 import io.hackle.android.internal.lifecycle.LifecycleListener
 import io.hackle.android.internal.session.SessionManager
 import io.hackle.android.internal.user.UserManager
+import io.hackle.sdk.common.Screen
 import io.hackle.sdk.common.User
 import io.hackle.sdk.core.internal.log.Logger
 import java.util.concurrent.atomic.AtomicReference

--- a/hackle-android-sdk/src/main/java/io/hackle/sdk/common/Screen.kt
+++ b/hackle-android-sdk/src/main/java/io/hackle/sdk/common/Screen.kt
@@ -1,14 +1,14 @@
-package io.hackle.android.internal.screen
+package io.hackle.sdk.common
 
 import android.app.Activity
 
-internal data class Screen(
+data class Screen(
     val name: String,
-    val className: String, // ScreenClass
+    val className: String,
 ) {
 
     companion object {
-        fun from(activity: Activity): Screen {
+        internal fun from(activity: Activity): Screen {
             val name = activity::class.java.simpleName
             return Screen(name, name)
         }

--- a/hackle-android-sdk/src/test/java/io/hackle/android/HackleAppTest.kt
+++ b/hackle-android-sdk/src/test/java/io/hackle/android/HackleAppTest.kt
@@ -10,7 +10,7 @@ import io.hackle.android.internal.pii.PIIEventManager
 import io.hackle.android.internal.pii.phonenumber.PhoneNumber
 import io.hackle.android.internal.push.token.PushTokenManager
 import io.hackle.android.internal.remoteconfig.HackleRemoteConfigImpl
-import io.hackle.android.internal.screen.Screen
+import io.hackle.sdk.common.Screen
 import io.hackle.android.internal.screen.ScreenManager
 import io.hackle.android.internal.session.Session
 import io.hackle.android.internal.session.SessionManager
@@ -811,8 +811,8 @@ class HackleAppTest {
     }
 
     @Test
-    fun `setCurrentScreen`() {
-        sut.setCurrentScreen("current_screen", "current_class")
+    fun setCurrentScreen() {
+        sut.setCurrentScreen(Screen("current_screen", "current_class"))
         verify(exactly = 1) {
             screenManager.setCurrentScreen(Screen("current_screen", "current_class"), any())
         }

--- a/hackle-android-sdk/src/test/java/io/hackle/android/HackleAppTest.kt
+++ b/hackle-android-sdk/src/test/java/io/hackle/android/HackleAppTest.kt
@@ -10,6 +10,8 @@ import io.hackle.android.internal.pii.PIIEventManager
 import io.hackle.android.internal.pii.phonenumber.PhoneNumber
 import io.hackle.android.internal.push.token.PushTokenManager
 import io.hackle.android.internal.remoteconfig.HackleRemoteConfigImpl
+import io.hackle.android.internal.screen.Screen
+import io.hackle.android.internal.screen.ScreenManager
 import io.hackle.android.internal.session.Session
 import io.hackle.android.internal.session.SessionManager
 import io.hackle.android.internal.sync.PollingSynchronizer
@@ -65,6 +67,9 @@ class HackleAppTest {
     private lateinit var sessionManager: SessionManager
 
     @RelaxedMockK
+    private lateinit var screenManager: ScreenManager
+
+    @RelaxedMockK
     private lateinit var eventProcessor: DefaultEventProcessor
 
     @RelaxedMockK
@@ -103,6 +108,7 @@ class HackleAppTest {
             userManager,
             workspaceManager,
             sessionManager,
+            screenManager,
             eventProcessor,
             pushTokenManager,
             notificationManager,
@@ -801,6 +807,14 @@ class HackleAppTest {
                 any(),
                 any()
             )
+        }
+    }
+
+    @Test
+    fun `setCurrentScreen`() {
+        sut.setCurrentScreen("current_screen", "current_class")
+        verify(exactly = 1) {
+            screenManager.setCurrentScreen(Screen.from("current_screen", "current_class"), any())
         }
     }
 }

--- a/hackle-android-sdk/src/test/java/io/hackle/android/HackleAppTest.kt
+++ b/hackle-android-sdk/src/test/java/io/hackle/android/HackleAppTest.kt
@@ -814,7 +814,7 @@ class HackleAppTest {
     fun `setCurrentScreen`() {
         sut.setCurrentScreen("current_screen", "current_class")
         verify(exactly = 1) {
-            screenManager.setCurrentScreen(Screen.from("current_screen", "current_class"), any())
+            screenManager.setCurrentScreen(Screen("current_screen", "current_class"), any())
         }
     }
 }

--- a/hackle-android-sdk/src/test/java/io/hackle/android/internal/bridge/HackleBridgeTest.kt
+++ b/hackle-android-sdk/src/test/java/io/hackle/android/internal/bridge/HackleBridgeTest.kt
@@ -1287,6 +1287,27 @@ class HackleBridgeTest {
             assertNull(data)
         }
     }
+    
+    @Test
+    fun `invoke set current screen with parameters`() {
+        every { app.setCurrentScreen(any(), any()) } answers { }
+        val parameters = mapOf(
+            "screenName" to "mainActivity",
+            "className" to "mainActivityClass",
+        )
+        val jsonString = createJsonString("setCurrentScreen", parameters)
+        val result = bridge.invoke(jsonString)
+        verify(exactly = 1) {
+            app.setCurrentScreen(
+                withArg { assertThat(it, `is`("mainActivity")) },
+                withArg { assertThat(it, `is`("mainActivityClass")) }
+            )
+        }
+        result.parseJson<BridgeResponse>().apply {
+            assertThat(success, `is`(true))
+            assertThat(message, `is`("OK"))
+        }
+    }
 
     @Test
     fun `invoke with show user explorer`() {

--- a/hackle-android-sdk/src/test/java/io/hackle/android/internal/bridge/HackleBridgeTest.kt
+++ b/hackle-android-sdk/src/test/java/io/hackle/android/internal/bridge/HackleBridgeTest.kt
@@ -8,6 +8,7 @@ import io.hackle.sdk.common.Event
 import io.hackle.sdk.common.HackleRemoteConfig
 import io.hackle.sdk.common.ParameterConfig
 import io.hackle.sdk.common.PropertyOperation
+import io.hackle.sdk.common.Screen
 import io.hackle.sdk.common.User
 import io.hackle.sdk.common.Variation
 import io.hackle.sdk.common.decision.Decision
@@ -1290,7 +1291,7 @@ class HackleBridgeTest {
     
     @Test
     fun `invoke set current screen with parameters`() {
-        every { app.setCurrentScreen(any(), any()) } answers { }
+        every { app.setCurrentScreen(any()) } answers { }
         val parameters = mapOf(
             "screenName" to "mainActivity",
             "className" to "mainActivityClass",
@@ -1299,8 +1300,7 @@ class HackleBridgeTest {
         val result = bridge.invoke(jsonString)
         verify(exactly = 1) {
             app.setCurrentScreen(
-                withArg { assertThat(it, `is`("mainActivity")) },
-                withArg { assertThat(it, `is`("mainActivityClass")) }
+                withArg { assertThat(it, `is`(Screen("mainActivity", "mainActivityClass"))) },
             )
         }
         result.parseJson<BridgeResponse>().apply {

--- a/hackle-android-sdk/src/test/java/io/hackle/android/internal/engagement/EngagementEventTrackerTest.kt
+++ b/hackle-android-sdk/src/test/java/io/hackle/android/internal/engagement/EngagementEventTrackerTest.kt
@@ -1,6 +1,6 @@
 package io.hackle.android.internal.engagement
 
-import io.hackle.android.internal.screen.Screen
+import io.hackle.sdk.common.Screen
 import io.hackle.android.internal.user.UserManager
 import io.hackle.sdk.common.Event
 import io.hackle.sdk.common.User

--- a/hackle-android-sdk/src/test/java/io/hackle/android/internal/engagement/EngagementManagerTest.kt
+++ b/hackle-android-sdk/src/test/java/io/hackle/android/internal/engagement/EngagementManagerTest.kt
@@ -1,7 +1,7 @@
 package io.hackle.android.internal.engagement
 
 import io.hackle.android.internal.lifecycle.Lifecycle
-import io.hackle.android.internal.screen.Screen
+import io.hackle.sdk.common.Screen
 import io.hackle.android.internal.screen.ScreenManager
 import io.hackle.android.internal.user.UserManager
 import io.mockk.Called

--- a/hackle-android-sdk/src/test/java/io/hackle/android/internal/event/DefaultEventProcessorTest.kt
+++ b/hackle-android-sdk/src/test/java/io/hackle/android/internal/event/DefaultEventProcessorTest.kt
@@ -8,7 +8,7 @@ import io.hackle.android.internal.event.dedup.DedupUserEventFilter
 import io.hackle.android.internal.event.dedup.UserEventDedupDeterminer
 import io.hackle.android.internal.lifecycle.AppState
 import io.hackle.android.internal.lifecycle.AppStateManager
-import io.hackle.android.internal.screen.Screen
+import io.hackle.sdk.common.Screen
 import io.hackle.android.internal.screen.ScreenManager
 import io.hackle.android.internal.screen.ScreenUserEventDecorator
 import io.hackle.android.internal.session.Session

--- a/hackle-android-sdk/src/test/java/io/hackle/android/internal/screen/ScreenEventTrackerTest.kt
+++ b/hackle-android-sdk/src/test/java/io/hackle/android/internal/screen/ScreenEventTrackerTest.kt
@@ -2,6 +2,7 @@ package io.hackle.android.internal.screen
 
 import io.hackle.android.internal.user.UserManager
 import io.hackle.sdk.common.Event
+import io.hackle.sdk.common.Screen
 import io.hackle.sdk.common.User
 import io.hackle.sdk.core.HackleCore
 import io.mockk.MockKAnnotations

--- a/hackle-android-sdk/src/test/java/io/hackle/android/internal/screen/ScreenManagerTest.kt
+++ b/hackle-android-sdk/src/test/java/io/hackle/android/internal/screen/ScreenManagerTest.kt
@@ -5,6 +5,7 @@ import io.hackle.android.internal.lifecycle.ActivityProvider
 import io.hackle.android.internal.lifecycle.ActivityState
 import io.hackle.android.internal.lifecycle.Lifecycle
 import io.hackle.android.internal.user.UserManager
+import io.hackle.sdk.common.Screen
 import io.hackle.sdk.common.User
 import io.mockk.every
 import io.mockk.mockk

--- a/hackle-android-sdk/src/test/java/io/hackle/android/internal/screen/ScreenTest.kt
+++ b/hackle-android-sdk/src/test/java/io/hackle/android/internal/screen/ScreenTest.kt
@@ -13,11 +13,5 @@ class ScreenTest {
         expectThat(screen).isEqualTo(Screen("ScreenActivity", "ScreenActivity"))
     }
 
-    @Test
-    fun `create from custom`() {
-        val screen = Screen.from("custom", "custom")
-        expectThat(screen).isEqualTo(Screen("custom", "custom"))
-    }
-
     private class ScreenActivity : Activity()
 }

--- a/hackle-android-sdk/src/test/java/io/hackle/android/internal/screen/ScreenTest.kt
+++ b/hackle-android-sdk/src/test/java/io/hackle/android/internal/screen/ScreenTest.kt
@@ -8,9 +8,15 @@ import strikt.assertions.isEqualTo
 class ScreenTest {
 
     @Test
-    fun `create form activity`() {
+    fun `create from activity`() {
         val screen = Screen.from(ScreenActivity())
         expectThat(screen).isEqualTo(Screen("ScreenActivity", "ScreenActivity"))
+    }
+
+    @Test
+    fun `create from custom`() {
+        val screen = Screen.from("custom", "custom")
+        expectThat(screen).isEqualTo(Screen("custom", "custom"))
     }
 
     private class ScreenActivity : Activity()

--- a/hackle-android-sdk/src/test/java/io/hackle/android/internal/screen/ScreenTest.kt
+++ b/hackle-android-sdk/src/test/java/io/hackle/android/internal/screen/ScreenTest.kt
@@ -1,6 +1,7 @@
 package io.hackle.android.internal.screen
 
 import android.app.Activity
+import io.hackle.sdk.common.Screen
 import org.junit.Test
 import strikt.api.expectThat
 import strikt.assertions.isEqualTo


### PR DESCRIPTION
## 개요
화면전환을 개발사에서 자체적으로 측정할 수 있도록 `setCurrentScreen`의 public api를 추가했습니다.

## 작업내용
### `Screen`, `setCurrentScreen(Screen)`를 수정했습니다.
- 외부에서 접근가능하게 public으로 수정했습니다.
- `Screen`을 common 패키지로 이동시켰습니다.
- 웹뷰 브릿지를 추가했습니다.

## 참고
`automaticScreenTracking`이 `false` 일 때 자동 화면 전환 추적이 안되고, `setCurrentScreen`으로는 추적되는 것을 확인했습니다.