### PR TITLE
push style uses in local

### DIFF
--- a/hackle-android-sdk/build.gradle
+++ b/hackle-android-sdk/build.gradle
@@ -83,12 +83,8 @@ task sourceJar(type: Jar) {
 
 task coverageReport(type: JacocoReport, dependsOn: 'testDebugUnitTest') {
     reports {
-        xml {
-            enabled = true
-        }
-        html {
-            enabled = true
-        }
+        xml.required.set(true)
+        html.required.set(true)
     }
 
     def fileFilter = ['**/R.class', '**/R$*.class', '**/BuildConfig.*', '**/Manifest*.*', '**/*Test*.*', 'android/**/*.*']

--- a/hackle-android-sdk/src/main/java/io/hackle/android/ui/notification/Constants.kt
+++ b/hackle-android-sdk/src/main/java/io/hackle/android/ui/notification/Constants.kt
@@ -7,6 +7,7 @@ internal object Constants {
 
     const val DEFAULT_NOTIFICATION_SMALL_ICON = "io_hackle_android_default_notification_small_icon"
     const val DEFAULT_NOTIFICATION_LARGE_ICON = "io_hackle_android_default_notification_large_icon"
+    const val DEFAULT_NOTIFICATION_COLOR = "io_hackle_android_default_notification_color"
 
     const val KEY_MESSAGE_ID = "google.message_id"
 

--- a/hackle-android-sdk/src/main/java/io/hackle/android/ui/notification/Constants.kt
+++ b/hackle-android-sdk/src/main/java/io/hackle/android/ui/notification/Constants.kt
@@ -5,6 +5,9 @@ internal object Constants {
     const val DEFAULT_NOTIFICATION_CHANNEL_ID = "io_hackle_android_default_notification_channel_id"
     const val DEFAULT_NOTIFICATION_CHANNEL_NAME = "default"
 
+    const val DEFAULT_NOTIFICATION_SMALL_ICON = "io_hackle_android_default_notification_small_icon"
+    const val DEFAULT_NOTIFICATION_LARGE_ICON = "io_hackle_android_default_notification_large_icon"
+
     const val KEY_MESSAGE_ID = "google.message_id"
 
     const val KEY_HACKLE = "hackle"

--- a/hackle-android-sdk/src/main/java/io/hackle/android/ui/notification/NotificationFactory.kt
+++ b/hackle-android-sdk/src/main/java/io/hackle/android/ui/notification/NotificationFactory.kt
@@ -65,6 +65,12 @@ internal object NotificationFactory {
         builder.setVisibility(NotificationCompat.VISIBILITY_PUBLIC)
     }
 
+    /**
+     * set small icon
+     *
+     * On Galaxy devices, only status bar icon is changed. App icon is shown in notification center
+     * For other devices, changed icon is shown in both status bar and notification center
+     */
     private fun setSmallIcon(context: Context, builder: NotificationCompat.Builder, data: NotificationData) {
         val metadata = context.packageManager
             .getApplicationInfo(context.packageName, PackageManager.GET_META_DATA)
@@ -76,7 +82,11 @@ internal object NotificationFactory {
         builder.setSmallIcon(smallIcon)
     }
 
-    // thumbnail icon == large icon
+    /**
+     * set large icon
+     * 
+     * thumbnail icon == large icon
+     */
     private fun setThumbnailIcon(context: Context, builder: NotificationCompat.Builder, data: NotificationData) {
         val imageUrl = data.thumbnailImageUrl
         val largeIconId = getResourceIdFromManifest(context, Constants.DEFAULT_NOTIFICATION_LARGE_ICON)
@@ -89,6 +99,13 @@ internal object NotificationFactory {
         builder.setLargeIcon(image)
     }
 
+    /**
+     * set small icon background color
+     *
+     * It is not changed in status bar.
+     * It is not changed on Galaxy devices.
+     * For other devices, the color behind small icon is changed in notification center.
+     */
     private fun setColor(context: Context, builder: NotificationCompat.Builder, data: NotificationData) {
         val colorFilter = data.iconColorFilter
         val colorId = getResourceIdFromManifest(context, Constants.DEFAULT_NOTIFICATION_COLOR)

--- a/hackle-android-sdk/src/main/java/io/hackle/android/ui/notification/NotificationFactory.kt
+++ b/hackle-android-sdk/src/main/java/io/hackle/android/ui/notification/NotificationFactory.kt
@@ -32,7 +32,7 @@ internal object NotificationFactory {
         setThumbnailIcon(context, builder, data)
         setContentTitle(builder, data)
         setContentText(builder, data)
-        setStyle(builder, data)
+        setBigTextStyle(builder, data)
         setContentIntent(context, builder, extras, data)
         setBigPictureStyle(context, builder, data)
         return builder.build()
@@ -93,7 +93,7 @@ internal object NotificationFactory {
         builder.setContentText(body)
     }
 
-    private fun setStyle(builder: NotificationCompat.Builder, data: NotificationData) {
+    private fun setBigTextStyle(builder: NotificationCompat.Builder, data: NotificationData) {
         val body = data.body ?: return
         builder.setStyle(NotificationCompat.BigTextStyle().bigText(body))
     }

--- a/hackle-android-sdk/src/main/java/io/hackle/android/ui/notification/NotificationFactory.kt
+++ b/hackle-android-sdk/src/main/java/io/hackle/android/ui/notification/NotificationFactory.kt
@@ -17,6 +17,8 @@ import com.bumptech.glide.Glide
 import io.hackle.android.ui.notification.Constants.DEFAULT_NOTIFICATION_CHANNEL_ID
 import io.hackle.android.ui.notification.Constants.DEFAULT_NOTIFICATION_CHANNEL_NAME
 import io.hackle.sdk.core.internal.log.Logger
+import androidx.core.net.toUri
+import androidx.core.graphics.toColorInt
 
 internal object NotificationFactory {
 
@@ -66,20 +68,32 @@ internal object NotificationFactory {
     private fun setSmallIcon(context: Context, builder: NotificationCompat.Builder, data: NotificationData) {
         val metadata = context.packageManager
             .getApplicationInfo(context.packageName, PackageManager.GET_META_DATA)
-        builder.setSmallIcon(metadata.icon)
+        // MARK:
+        //  1. manifest
+        //  2. app icon
+        val smallIcon = getResourceIdFromManifest(context, Constants.DEFAULT_NOTIFICATION_SMALL_ICON) ?: metadata.icon
+
+        builder.setSmallIcon(smallIcon)
 
         if (!data.iconColorFilter.isNullOrEmpty()) {
             try {
-                builder.color = Color.parseColor(data.iconColorFilter)
+                builder.color = data.iconColorFilter.toColorInt()
             } catch (_: Exception) {
                 log.debug { "Hex color parsing error: ${data.iconColorFilter}" }
             }
         }
     }
 
+    // thumbnail icon == large icon
     private fun setThumbnailIcon(context: Context, builder: NotificationCompat.Builder, data: NotificationData) {
-        val imageUrl = data.thumbnailImageUrl ?: return
-        val image = loadImageFromUrl(context, imageUrl) ?: return
+        val imageUrl = data.thumbnailImageUrl
+        val largeIconId = getResourceIdFromManifest(context, Constants.DEFAULT_NOTIFICATION_LARGE_ICON)
+        // MARK:
+        //  1. remote
+        //  2. manifest
+        //  3. not set
+        val image = loadImageFromUrl(context, imageUrl) ?: loadImageFromResource(context, largeIconId) ?: return
+
         builder.setLargeIcon(image)
     }
 
@@ -98,11 +112,16 @@ internal object NotificationFactory {
         builder.setStyle(NotificationCompat.BigTextStyle().bigText(body))
     }
 
-    private fun setContentIntent(context: Context, builder: NotificationCompat.Builder, extras: Bundle, data: NotificationData) {
+    private fun setContentIntent(
+        context: Context,
+        builder: NotificationCompat.Builder,
+        extras: Bundle,
+        data: NotificationData
+    ) {
         val notificationIntent = Intent(context, NotificationTrampolineActivity::class.java)
         notificationIntent.flags = Intent.FLAG_ACTIVITY_SINGLE_TOP or Intent.FLAG_ACTIVITY_CLEAR_TOP
         data.link?.apply {
-            notificationIntent.data = Uri.parse(this)
+            notificationIntent.data = this.toUri()
         }
         notificationIntent.putExtras(extras)
         val pendingIntent = PendingIntent.getActivity(
@@ -125,27 +144,78 @@ internal object NotificationFactory {
         builder.setStyle(bigPictureStyle)
     }
 
-    private fun setBigThumbnailIcon(context: Context, bigPictureStyle: NotificationCompat.BigPictureStyle, data: NotificationData) {
+    private fun setBigThumbnailIcon(
+        context: Context,
+        bigPictureStyle: NotificationCompat.BigPictureStyle,
+        data: NotificationData
+    ) {
         val imageUrl = data.thumbnailImageUrl ?: return
         val image = loadImageFromUrl(context, imageUrl) ?: return
         bigPictureStyle.bigLargeIcon(image)
     }
 
-    private fun setBigPicture(context: Context, bigPictureStyle: NotificationCompat.BigPictureStyle, data: NotificationData) {
+    private fun setBigPicture(
+        context: Context,
+        bigPictureStyle: NotificationCompat.BigPictureStyle,
+        data: NotificationData
+    ) {
         val imageUrl = data.largeImageUrl ?: return
         val image = loadImageFromUrl(context, imageUrl) ?: return
         bigPictureStyle.bigPicture(image)
     }
 
-    private fun loadImageFromUrl(context: Context, url: String): Bitmap? {
+    private fun getResourceIdFromManifest(context: Context, key: String): Int? {
         try {
+            val appInfo = context.packageManager.getApplicationInfo(
+                context.packageName,
+                PackageManager.GET_META_DATA
+            )
+
+            val metaData = appInfo.metaData
+            if (metaData != null && metaData.containsKey(key)) {
+                val resourceId = metaData.getInt(key)
+                if (resourceId != 0) {
+                    return resourceId
+                }
+            }
+        } catch (_: Exception) {
+            log.debug { "Failed to get resource ID from manifest: $key" }
+        }
+
+        return null
+
+    }
+
+    private fun loadImageFromUrl(context: Context, url: String?): Bitmap? {
+        try {
+            if (url.isNullOrEmpty()) {
+                return null
+            }
+
             return Glide.with(context)
                 .asBitmap()
                 .load(url)
                 .submit()
                 .get()
-        } catch (e: Exception) {
+        } catch (_: Exception) {
             log.debug { "Failed to load image: $url" }
+        }
+        return null
+    }
+
+    private fun loadImageFromResource(context: Context, resourceId: Int?): Bitmap? {
+        try {
+            if (resourceId == null || resourceId == 0) {
+                return null
+            }
+
+            return Glide.with(context)
+                .asBitmap()
+                .load(resourceId)
+                .submit()
+                .get()
+        } catch (_: Exception) {
+            log.debug { "Failed to load image resource: $resourceId" }
         }
         return null
     }


### PR DESCRIPTION
## 개요
푸시 알림의 아이콘과 색상을 사용자가 직접 설정할 수 있는 기능을 추가합니다. 
AndroidManifest 또는 원격(Remote) 설정을 통해 smal lIcon, large Icon, icon Color을 커스터마이징할 수 있습니다.

## 작업 내용
### 푸시 알림 스타일링 기능을 추가합니다.
- AndroidManifest.xml 메타데이터를 통해 푸시 알림의 작은 아이콘, 큰 아이콘, 색상을 설정하는 기능 추가
- 설정 우선 순위는 아래와 같습니다.
  1. remote push message에 포함된 값
  2. AndroidManifest metadata에 명시된 값
  3. default
    - (small icon) app icon
    - (large icon & color) not set

#### example
```xml
<manifest>
    <application>
...
        <meta-data
            android:name="io_hackle_android_default_notification_small_icon"
            android:resource="@drawable/ic_push_small"/>

        <meta-data
            android:name="io_hackle_android_default_notification_large_icon"
            android:resource="@drawable/ic_push_large"/>

        <meta-data
            android:name="io_hackle_android_default_notification_color"
            android:resource="@color/pie" />
...
    </application>
</manifest>
```

### `build.gradle` Jacoco 설정 업데이트
- 최신 gradle 에서 에러나는 것을 수정했습니다. 
- 현재 gradle 버전(7.2) ~ 최신 버전까지 모두 정상동작합니다.

## 참고
갤럭시 폰과 일반 안드로이드 폰의 동작이 상이합니다.

small icon / large icon / color 수정 시 동작
| 구분 | small icon | large icon | color |
| -- | -- | -- | -- |
| 갤럭시 | status bar 에만 반영 | 알림센터에 노출 | 적용 안됨 |
| 일반 안드로이드 | status bar & 알림 센터 에 반영 | 알림센터에 노출 | 알림 센터 small icon background |

small icon에 아이콘 적용 안할 시 동작
| 구분 | 동작 |
| -- | -- |
| 갤럭시 | status bar와 알림센터에 앱 아이콘 노출 |
| 일반 안드로이드 | stats bar와 알림센터에 흰색 빈 아이콘 노출 |

