### PR TITLE
forced inject insets below android 10

### DIFF
--- a/hackle-android-sdk/src/main/java/io/hackle/android/ui/inappmessage/InAppMessageControllerFactory.kt
+++ b/hackle-android-sdk/src/main/java/io/hackle/android/ui/inappmessage/InAppMessageControllerFactory.kt
@@ -2,6 +2,7 @@ package io.hackle.android.ui.inappmessage
 
 import android.app.Activity
 import android.os.Build
+import android.view.View
 import androidx.core.view.ViewCompat
 import androidx.core.view.doOnLayout
 import io.hackle.android.internal.inappmessage.presentation.InAppMessagePresentationContext
@@ -48,6 +49,7 @@ internal class InAppMessageControllerFactory(
             }
         } else {
             view.doOnLayout {
+                if (!isEdgeToEdgeEnabled(view)) return@doOnLayout
                 val rootInsets = ViewCompat.getRootWindowInsets(view)
                 if (rootInsets != null) {
                     view.onApplyWindowInsets(rootInsets)
@@ -55,4 +57,14 @@ internal class InAppMessageControllerFactory(
             }
         }
     }
+
+    private fun isEdgeToEdgeEnabled(view: InAppMessageView): Boolean {
+        val activity = view.activity ?: return false
+        val flags = activity.window.decorView.systemUiVisibility
+        return (flags and View.SYSTEM_UI_FLAG_LAYOUT_STABLE) != 0 &&
+                (flags and View.SYSTEM_UI_FLAG_LAYOUT_HIDE_NAVIGATION) != 0 &&
+                (flags and View.SYSTEM_UI_FLAG_LAYOUT_FULLSCREEN) != 0
+
+    }
+
 }

--- a/hackle-android-sdk/src/main/java/io/hackle/android/ui/inappmessage/InAppMessageControllerFactory.kt
+++ b/hackle-android-sdk/src/main/java/io/hackle/android/ui/inappmessage/InAppMessageControllerFactory.kt
@@ -1,7 +1,9 @@
 package io.hackle.android.ui.inappmessage
 
 import android.app.Activity
+import android.os.Build
 import androidx.core.view.ViewCompat
+import androidx.core.view.doOnLayout
 import io.hackle.android.internal.inappmessage.presentation.InAppMessagePresentationContext
 import io.hackle.android.ui.inappmessage.layout.view.InAppMessageView
 import io.hackle.android.ui.inappmessage.layout.view.InAppMessageViewController
@@ -39,9 +41,18 @@ internal class InAppMessageControllerFactory(
     // add margin when enableEdgeToEdge
     // ref. https://developer.android.com/develop/ui/views/layout/edge-to-edge#system-bars-insets
     private fun setOnApplyWindowInsetsListener(view: InAppMessageView) {
-        ViewCompat.setOnApplyWindowInsetsListener(view) { v, windowInsets ->
-            (v as? InAppMessageView)?.onApplyWindowInsets(windowInsets)
-            windowInsets
+        if (Build.VERSION.SDK_INT >= Build.VERSION_CODES.R) {
+            ViewCompat.setOnApplyWindowInsetsListener(view) { v, windowInsets ->
+                (v as? InAppMessageView)?.onApplyWindowInsets(windowInsets)
+                windowInsets
+            }
+        } else {
+            view.doOnLayout {
+                val rootInsets = ViewCompat.getRootWindowInsets(view)
+                if (rootInsets != null) {
+                    view.onApplyWindowInsets(rootInsets)
+                }
+            }
         }
     }
 }


### PR DESCRIPTION
## 개요
Android 11 미만에서 시스템 UI에 InAppMessage가 가리는 이슈를 수정하였습니다.
## 작업내용
| 구분 | 작업 |
| -- | -- |
| Android 11 이상 | `ViewCompat.setOnApplyWindowInsetsListener`를 이용해서 람다함수 내에서 처리 insets를 전달받아 view에 적용 |
| Android 11 미만 | 뷰가 레이아웃 된 후 insets를 가져와서 view에 적용 |
> Android 11 미만에서는 setOnApplyWindowInsetsListener가 정상적으로 동작하지 않아 뷰 레이아웃이 완료된 후 insets를 뷰에 직접 적용

## 참고
#294 

