### PR TITLE
support push channel

### DIFF
--- a/hackle-android-sdk/src/main/java/io/hackle/android/ui/notification/Constants.kt
+++ b/hackle-android-sdk/src/main/java/io/hackle/android/ui/notification/Constants.kt
@@ -4,6 +4,9 @@ internal object Constants {
 
     const val DEFAULT_NOTIFICATION_CHANNEL_ID = "io_hackle_android_default_notification_channel_id"
     const val DEFAULT_NOTIFICATION_CHANNEL_NAME = "default"
+    
+    const val HIGH_NOTIFICATION_CHANNEL_ID = "io_hackle_android_high_notification_channel_id"
+    const val HIGH_NOTIFICATION_CHANNEL_NAME = "high"
 
     const val DEFAULT_NOTIFICATION_SMALL_ICON = "io_hackle_android_default_notification_small_icon"
     const val DEFAULT_NOTIFICATION_LARGE_ICON = "io_hackle_android_default_notification_large_icon"

--- a/hackle-android-sdk/src/main/java/io/hackle/android/ui/notification/Constants.kt
+++ b/hackle-android-sdk/src/main/java/io/hackle/android/ui/notification/Constants.kt
@@ -12,6 +12,7 @@ internal object Constants {
     const val KEY_MESSAGE_ID = "google.message_id"
 
     const val KEY_HACKLE = "hackle"
+    const val KEY_CHANNEL_ID = "channelId"
     const val KEY_WORKSPACE_ID = "workspaceId"
     const val KEY_ENVIRONMENT_ID = "environmentId"
     const val KEY_PUSH_MESSAGE_ID = "pushMessageId"

--- a/hackle-android-sdk/src/main/java/io/hackle/android/ui/notification/NotificationBroadcastReceiver.kt
+++ b/hackle-android-sdk/src/main/java/io/hackle/android/ui/notification/NotificationBroadcastReceiver.kt
@@ -52,8 +52,7 @@ internal class NotificationBroadcastReceiver : BroadcastReceiver() {
         }
 
         try {
-            val channelId = getChannelId(intent)
-            val notification = NotificationFactory.createNotification(context, notificationExtras, channelId, notificationData)
+            val notification = NotificationFactory.createNotification(context, notificationExtras, notificationData)
             val notificationManager = NotificationManagerCompat.from(context)
             notificationManager.notify(TAG, notificationData.notificationId, notification)
         } catch (e: Exception) {
@@ -80,10 +79,6 @@ internal class NotificationBroadcastReceiver : BroadcastReceiver() {
         }
 
         return false
-    }
-    
-    private fun getChannelId(intent: Intent): String  {
-        return intent.getStringExtra("google.c.a.c_id") ?: DEFAULT_NOTIFICATION_CHANNEL_ID
     }
 
     companion object {

--- a/hackle-android-sdk/src/main/java/io/hackle/android/ui/notification/NotificationBroadcastReceiver.kt
+++ b/hackle-android-sdk/src/main/java/io/hackle/android/ui/notification/NotificationBroadcastReceiver.kt
@@ -7,6 +7,7 @@ import android.content.Context
 import android.content.Intent
 import androidx.core.app.NotificationManagerCompat
 import io.hackle.android.internal.task.TaskExecutors.runOnBackground
+import io.hackle.android.ui.notification.Constants.DEFAULT_NOTIFICATION_CHANNEL_ID
 import io.hackle.sdk.core.internal.log.Logger
 
 internal class NotificationBroadcastReceiver : BroadcastReceiver() {
@@ -51,7 +52,8 @@ internal class NotificationBroadcastReceiver : BroadcastReceiver() {
         }
 
         try {
-            val notification = NotificationFactory.createNotification(context, notificationExtras, notificationData)
+            val channelId = getChannelId(intent)
+            val notification = NotificationFactory.createNotification(context, notificationExtras, channelId, notificationData)
             val notificationManager = NotificationManagerCompat.from(context)
             notificationManager.notify(TAG, notificationData.notificationId, notification)
         } catch (e: Exception) {
@@ -78,6 +80,10 @@ internal class NotificationBroadcastReceiver : BroadcastReceiver() {
         }
 
         return false
+    }
+    
+    private fun getChannelId(intent: Intent): String  {
+        return intent.getStringExtra("google.c.a.c_id") ?: DEFAULT_NOTIFICATION_CHANNEL_ID
     }
 
     companion object {

--- a/hackle-android-sdk/src/main/java/io/hackle/android/ui/notification/NotificationData.kt
+++ b/hackle-android-sdk/src/main/java/io/hackle/android/ui/notification/NotificationData.kt
@@ -60,7 +60,7 @@ internal data class NotificationData(
                 val hackle = checkNotNull(data.getString(KEY_HACKLE))
                     .parseJson<Map<String, Any>>()
                 return NotificationData(
-                    channelId = checkNotNull(data.getString(KEY_CHANNEL_ID)),
+                    channelId = checkNotNull(hackle[KEY_CHANNEL_ID] as? String),
                     messageId = checkNotNull(data.getString(KEY_MESSAGE_ID)),
                     workspaceId = checkNotNull(hackle[KEY_WORKSPACE_ID] as? Number).toLong(),
                     environmentId = checkNotNull(hackle[KEY_ENVIRONMENT_ID] as? Number).toLong(),

--- a/hackle-android-sdk/src/main/java/io/hackle/android/ui/notification/NotificationData.kt
+++ b/hackle-android-sdk/src/main/java/io/hackle/android/ui/notification/NotificationData.kt
@@ -2,6 +2,7 @@ package io.hackle.android.ui.notification
 
 import android.content.Intent
 import io.hackle.android.internal.utils.json.parseJson
+import io.hackle.android.ui.notification.Constants.DEFAULT_NOTIFICATION_CHANNEL_ID
 import io.hackle.android.ui.notification.Constants.KEY_BODY
 import io.hackle.android.ui.notification.Constants.KEY_CAMPAIGN_TYPE
 import io.hackle.android.ui.notification.Constants.KEY_CHANNEL_ID
@@ -60,7 +61,8 @@ internal data class NotificationData(
                 val hackle = checkNotNull(data.getString(KEY_HACKLE))
                     .parseJson<Map<String, Any>>()
                 return NotificationData(
-                    channelId = checkNotNull(hackle[KEY_CHANNEL_ID] as? String),
+                    channelId = (hackle[KEY_CHANNEL_ID] as? String) 
+                        ?: DEFAULT_NOTIFICATION_CHANNEL_ID,
                     messageId = checkNotNull(data.getString(KEY_MESSAGE_ID)),
                     workspaceId = checkNotNull(hackle[KEY_WORKSPACE_ID] as? Number).toLong(),
                     environmentId = checkNotNull(hackle[KEY_ENVIRONMENT_ID] as? Number).toLong(),

--- a/hackle-android-sdk/src/main/java/io/hackle/android/ui/notification/NotificationData.kt
+++ b/hackle-android-sdk/src/main/java/io/hackle/android/ui/notification/NotificationData.kt
@@ -4,6 +4,7 @@ import android.content.Intent
 import io.hackle.android.internal.utils.json.parseJson
 import io.hackle.android.ui.notification.Constants.KEY_BODY
 import io.hackle.android.ui.notification.Constants.KEY_CAMPAIGN_TYPE
+import io.hackle.android.ui.notification.Constants.KEY_CHANNEL_ID
 import io.hackle.android.ui.notification.Constants.KEY_CLICK_ACTION
 import io.hackle.android.ui.notification.Constants.KEY_COLOR_FILTER
 import io.hackle.android.ui.notification.Constants.KEY_DEBUG
@@ -25,6 +26,7 @@ import io.hackle.android.ui.notification.Constants.KEY_TITLE
 import io.hackle.android.ui.notification.Constants.KEY_WORKSPACE_ID
 
 internal data class NotificationData(
+    val channelId: String,
     val messageId: String,
     val workspaceId: Long,
     val environmentId: Long,
@@ -58,6 +60,7 @@ internal data class NotificationData(
                 val hackle = checkNotNull(data.getString(KEY_HACKLE))
                     .parseJson<Map<String, Any>>()
                 return NotificationData(
+                    channelId = checkNotNull(data.getString(KEY_CHANNEL_ID)),
                     messageId = checkNotNull(data.getString(KEY_MESSAGE_ID)),
                     workspaceId = checkNotNull(hackle[KEY_WORKSPACE_ID] as? Number).toLong(),
                     environmentId = checkNotNull(hackle[KEY_ENVIRONMENT_ID] as? Number).toLong(),

--- a/hackle-android-sdk/src/main/java/io/hackle/android/ui/notification/NotificationData.kt
+++ b/hackle-android-sdk/src/main/java/io/hackle/android/ui/notification/NotificationData.kt
@@ -61,8 +61,7 @@ internal data class NotificationData(
                 val hackle = checkNotNull(data.getString(KEY_HACKLE))
                     .parseJson<Map<String, Any>>()
                 return NotificationData(
-                    channelId = (hackle[KEY_CHANNEL_ID] as? String) 
-                        ?: DEFAULT_NOTIFICATION_CHANNEL_ID,
+                    channelId = channelId(hackle[KEY_CHANNEL_ID] as? String),
                     messageId = checkNotNull(data.getString(KEY_MESSAGE_ID)),
                     workspaceId = checkNotNull(hackle[KEY_WORKSPACE_ID] as? Number).toLong(),
                     environmentId = checkNotNull(hackle[KEY_ENVIRONMENT_ID] as? Number).toLong(),
@@ -90,6 +89,13 @@ internal data class NotificationData(
             } catch (_: Exception) {
             }
             return null
+        }
+        
+        fun channelId(channelId: String?): String {
+            if(channelId.isNullOrEmpty()) {
+                return DEFAULT_NOTIFICATION_CHANNEL_ID
+            }
+            return channelId
         }
     }
 }

--- a/hackle-android-sdk/src/main/java/io/hackle/android/ui/notification/NotificationFactory.kt
+++ b/hackle-android-sdk/src/main/java/io/hackle/android/ui/notification/NotificationFactory.kt
@@ -54,42 +54,37 @@ internal object NotificationFactory {
         if (channel == null) {
             log.debug { "$channelId channel does not exist on device." }
             if (channelId == HIGH_NOTIFICATION_CHANNEL_ID) {
-                return getHighNotificationChannelId(notificationManager)
+                return createHighNotificationChannelId(notificationManager)
             }
-            return getDefaultNotificationChannelId(notificationManager)
+            return createDefaultNotificationChannelId(notificationManager)
         }
         
         return channelId
     }
 
     @RequiresApi(Build.VERSION_CODES.O)
-    private fun getDefaultNotificationChannelId(notificationManager: NotificationManager): String {
-        if (notificationManager.getNotificationChannel(DEFAULT_NOTIFICATION_CHANNEL_ID) == null) {
-            log.debug { "Default notification channel does not exist on device." }
-            val channel = NotificationChannel(
-                DEFAULT_NOTIFICATION_CHANNEL_ID,
-                DEFAULT_NOTIFICATION_CHANNEL_NAME,
-                NotificationManager.IMPORTANCE_DEFAULT
-            )
-            notificationManager.createNotificationChannel(channel)
-            log.debug { "Created default notification channel name: $DEFAULT_NOTIFICATION_CHANNEL_NAME" }
-        }
+    private fun createDefaultNotificationChannelId(notificationManager: NotificationManager): String {
+        val channel = NotificationChannel(
+            DEFAULT_NOTIFICATION_CHANNEL_ID,
+            DEFAULT_NOTIFICATION_CHANNEL_NAME,
+            NotificationManager.IMPORTANCE_DEFAULT
+        )
+        notificationManager.createNotificationChannel(channel)
+        log.debug { "Created default notification channel name: $DEFAULT_NOTIFICATION_CHANNEL_NAME" }
         
         return DEFAULT_NOTIFICATION_CHANNEL_ID
     }
 
     @RequiresApi(Build.VERSION_CODES.O)
-    private fun getHighNotificationChannelId(notificationManager: NotificationManager): String {
-        if (notificationManager.getNotificationChannel(DEFAULT_NOTIFICATION_CHANNEL_ID) == null) {
-            log.debug { "High notification channel does not exist on device." }
-            val channel = NotificationChannel(
-                HIGH_NOTIFICATION_CHANNEL_ID,
-                HIGH_NOTIFICATION_CHANNEL_NAME,
-                NotificationManager.IMPORTANCE_HIGH
-            )
-            notificationManager.createNotificationChannel(channel)
-            log.debug { "Created high notification channel name: $HIGH_NOTIFICATION_CHANNEL_NAME" }
-        }
+    private fun createHighNotificationChannelId(notificationManager: NotificationManager): String {
+        log.debug { "High notification channel does not exist on device." }
+        val channel = NotificationChannel(
+            HIGH_NOTIFICATION_CHANNEL_ID,
+            HIGH_NOTIFICATION_CHANNEL_NAME,
+            NotificationManager.IMPORTANCE_HIGH
+        )
+        notificationManager.createNotificationChannel(channel)
+        log.debug { "Created high notification channel name: $HIGH_NOTIFICATION_CHANNEL_NAME" }
 
         return HIGH_NOTIFICATION_CHANNEL_ID
     }

--- a/hackle-android-sdk/src/main/java/io/hackle/android/ui/notification/NotificationFactory.kt
+++ b/hackle-android-sdk/src/main/java/io/hackle/android/ui/notification/NotificationFactory.kt
@@ -19,6 +19,8 @@ import io.hackle.android.ui.notification.Constants.DEFAULT_NOTIFICATION_CHANNEL_
 import io.hackle.sdk.core.internal.log.Logger
 import androidx.core.net.toUri
 import androidx.core.graphics.toColorInt
+import io.hackle.android.ui.notification.Constants.HIGH_NOTIFICATION_CHANNEL_ID
+import io.hackle.android.ui.notification.Constants.HIGH_NOTIFICATION_CHANNEL_NAME
 
 internal object NotificationFactory {
 
@@ -51,10 +53,13 @@ internal object NotificationFactory {
         val channel = notificationManager.getNotificationChannel(channelId)
         if (channel == null) {
             log.debug { "$channelId channel does not exist on device." }
+            if (channelId == HIGH_NOTIFICATION_CHANNEL_ID) {
+                return getHighNotificationChannelId(notificationManager)
+            }
             return getDefaultNotificationChannelId(notificationManager)
-        } else {
-            return channelId
         }
+        
+        return channelId
     }
 
     @RequiresApi(Build.VERSION_CODES.O)
@@ -71,6 +76,22 @@ internal object NotificationFactory {
         }
         
         return DEFAULT_NOTIFICATION_CHANNEL_ID
+    }
+
+    @RequiresApi(Build.VERSION_CODES.O)
+    private fun getHighNotificationChannelId(notificationManager: NotificationManager): String {
+        if (notificationManager.getNotificationChannel(DEFAULT_NOTIFICATION_CHANNEL_ID) == null) {
+            log.debug { "High notification channel does not exist on device." }
+            val channel = NotificationChannel(
+                HIGH_NOTIFICATION_CHANNEL_ID,
+                HIGH_NOTIFICATION_CHANNEL_NAME,
+                NotificationManager.IMPORTANCE_HIGH
+            )
+            notificationManager.createNotificationChannel(channel)
+            log.debug { "Created high notification channel name: $HIGH_NOTIFICATION_CHANNEL_NAME" }
+        }
+
+        return HIGH_NOTIFICATION_CHANNEL_ID
     }
 
     private fun setPriority(builder: NotificationCompat.Builder) {

--- a/hackle-android-sdk/src/main/java/io/hackle/android/ui/notification/NotificationFactory.kt
+++ b/hackle-android-sdk/src/main/java/io/hackle/android/ui/notification/NotificationFactory.kt
@@ -24,9 +24,9 @@ internal object NotificationFactory {
 
     private val log = Logger<NotificationFactory>()
 
-    fun createNotification(context: Context, extras: Bundle, channelId: String, data: NotificationData): Notification {
+    fun createNotification(context: Context, extras: Bundle, data: NotificationData): Notification {
         val channelId = if(Build.VERSION.SDK_INT >= Build.VERSION_CODES.O) {
-            resolveNotificationChannelId(context, channelId)
+            resolveNotificationChannelId(context, data.channelId)
         } else {
             DEFAULT_NOTIFICATION_CHANNEL_ID
         }

--- a/hackle-android-sdk/src/main/java/io/hackle/android/ui/notification/NotificationFactory.kt
+++ b/hackle-android-sdk/src/main/java/io/hackle/android/ui/notification/NotificationFactory.kt
@@ -56,21 +56,23 @@ internal object NotificationFactory {
             if (channelId == HIGH_NOTIFICATION_CHANNEL_ID) {
                 return createHighNotificationChannelId(notificationManager)
             }
-            return createDefaultNotificationChannelId(notificationManager)
+            return resolveDefaultNotificationChannelId(notificationManager)
         }
         
         return channelId
     }
 
     @RequiresApi(Build.VERSION_CODES.O)
-    private fun createDefaultNotificationChannelId(notificationManager: NotificationManager): String {
-        val channel = NotificationChannel(
-            DEFAULT_NOTIFICATION_CHANNEL_ID,
-            DEFAULT_NOTIFICATION_CHANNEL_NAME,
-            NotificationManager.IMPORTANCE_DEFAULT
-        )
-        notificationManager.createNotificationChannel(channel)
-        log.debug { "Created default notification channel name: $DEFAULT_NOTIFICATION_CHANNEL_NAME" }
+    private fun resolveDefaultNotificationChannelId(notificationManager: NotificationManager): String {
+        if(notificationManager.getNotificationChannel(DEFAULT_NOTIFICATION_CHANNEL_ID) == null) {
+            val channel = NotificationChannel(
+                DEFAULT_NOTIFICATION_CHANNEL_ID,
+                DEFAULT_NOTIFICATION_CHANNEL_NAME,
+                NotificationManager.IMPORTANCE_DEFAULT
+            )
+            notificationManager.createNotificationChannel(channel)
+            log.debug { "Created default notification channel name: $DEFAULT_NOTIFICATION_CHANNEL_NAME" }
+        }
         
         return DEFAULT_NOTIFICATION_CHANNEL_ID
     }

--- a/hackle-android-sdk/src/main/java/io/hackle/android/ui/notification/NotificationFactory.kt
+++ b/hackle-android-sdk/src/main/java/io/hackle/android/ui/notification/NotificationFactory.kt
@@ -34,7 +34,6 @@ internal object NotificationFactory {
         }
         val builder = NotificationCompat.Builder(context, channelId)
         builder.setAutoCancel(true)
-        //setPriority(builder)
         setVisibility(builder)
         setSmallIcon(context, builder, data)
         setThumbnailIcon(context, builder, data)

--- a/hackle-android-sdk/src/test/java/io/hackle/android/internal/notification/NotificationEventTest.kt
+++ b/hackle-android-sdk/src/test/java/io/hackle/android/internal/notification/NotificationEventTest.kt
@@ -12,6 +12,7 @@ class NotificationEventTest {
     @Test
     fun `notification data to event`() {
         val from = NotificationData(
+            channelId = "hackle_default_channel",
             messageId = "abcd1234",
             workspaceId = 123L,
             environmentId = 456L,

--- a/hackle-android-sdk/src/test/java/io/hackle/android/internal/notification/NotificationManagerTest.kt
+++ b/hackle-android-sdk/src/test/java/io/hackle/android/internal/notification/NotificationManagerTest.kt
@@ -38,7 +38,19 @@ class NotificationManagerTest {
         executor = mockk()
         every { executor.execute(any()) } answers { firstArg<Runnable>().run() }
         workspaceFetcher = mockk()
-        every { workspaceFetcher.fetch() } returns WorkspaceImpl(111L, 222L, emptyList(), emptyList(), emptyMap(), emptyMap(), emptyMap(), emptyMap(), emptyMap(), emptyMap(), emptyList())
+        every { workspaceFetcher.fetch() } returns WorkspaceImpl(
+            111L,
+            222L,
+            emptyList(),
+            emptyList(),
+            emptyMap(),
+            emptyMap(),
+            emptyMap(),
+            emptyMap(),
+            emptyMap(),
+            emptyMap(),
+            emptyList()
+        )
 
         manager = NotificationManager(
             core = core,
@@ -51,7 +63,29 @@ class NotificationManagerTest {
 
     @Test
     fun `track push click event when notification data received`() {
-        val data = NotificationData("abcd1234", 111L, 222L, 1111L, 2222L, 3333L, 4444L, true, "#FF00FF", "foo", "bar", "https://foo.bar/image", "https://foo.foo", NotificationClickAction.APP_OPEN, "foo://bar", 1L, 2L, 3L, "JOURNEY", true)
+        val data = NotificationData(
+            "hackle",
+            "abcd1234",
+            111L,
+            222L,
+            1111L,
+            2222L,
+            3333L,
+            4444L,
+            true,
+            "#FF00FF",
+            "foo",
+            "bar",
+            "https://foo.bar/image",
+            "https://foo.foo",
+            NotificationClickAction.APP_OPEN,
+            "foo://bar",
+            1L,
+            2L,
+            3L,
+            "JOURNEY",
+            true
+        )
         val timestamp = System.currentTimeMillis()
         manager.onNotificationDataReceived(data, timestamp)
 
@@ -73,16 +107,104 @@ class NotificationManagerTest {
     @Test
     fun `save notification data if environment is not same`() {
         val timestamp = System.currentTimeMillis()
-        val correctData = NotificationData("0", 111L, 222L, 1111L, 2222L, 3333L, 4444L, true, "#FF00FF", "foo", "bar", "https://foo.bar/image", "https://foo.foo", NotificationClickAction.APP_OPEN, "foo://bar", 1L, 2L, 3L, "PUSH_MESSAGE", true)
+        val correctData = NotificationData(
+            "hackle",
+            "0",
+            111L,
+            222L,
+            1111L,
+            2222L,
+            3333L,
+            4444L,
+            true,
+            "#FF00FF",
+            "foo",
+            "bar",
+            "https://foo.bar/image",
+            "https://foo.foo",
+            NotificationClickAction.APP_OPEN,
+            "foo://bar",
+            1L,
+            2L,
+            3L,
+            "PUSH_MESSAGE",
+            true
+        )
         manager.onNotificationDataReceived(correctData, timestamp)
 
-        val diffWorkspaceData = NotificationData("1", 333L, 222L, 1111L, 2222L, 3333L, 4444L, true, "#FF00FF", "foo", "bar", "https://foo.bar/image", "https://foo.foo", NotificationClickAction.APP_OPEN, "foo://bar", 2L, 3L, 4L, "PUSH_MESSAGE", true)
+        val diffWorkspaceData = NotificationData(
+            "hackle",
+            "1",
+            333L,
+            222L,
+            1111L,
+            2222L,
+            3333L,
+            4444L,
+            true,
+            "#FF00FF",
+            "foo",
+            "bar",
+            "https://foo.bar/image",
+            "https://foo.foo",
+            NotificationClickAction.APP_OPEN,
+            "foo://bar",
+            2L,
+            3L,
+            4L,
+            "PUSH_MESSAGE",
+            true
+        )
         manager.onNotificationDataReceived(diffWorkspaceData, 2L)
 
-        val diffEnvironmentData = NotificationData("2", 111L, 333L, 1111L, 2222L, 3333L, 4444L, true, "#FF00FF", "foo", "bar", "https://foo.bar/image", "https://foo.foo", NotificationClickAction.APP_OPEN, "foo://bar", 3L, 4L, 5L, "PUSH_MESSAGE", true)
+        val diffEnvironmentData = NotificationData(
+            "hackle",
+            "2",
+            111L,
+            333L,
+            1111L,
+            2222L,
+            3333L,
+            4444L,
+            true,
+            "#FF00FF",
+            "foo",
+            "bar",
+            "https://foo.bar/image",
+            "https://foo.foo",
+            NotificationClickAction.APP_OPEN,
+            "foo://bar",
+            3L,
+            4L,
+            5L,
+            "PUSH_MESSAGE",
+            true
+        )
         manager.onNotificationDataReceived(diffEnvironmentData, 3L)
 
-        val bothDiffData = NotificationData("4", 333L, 333L, 1111L, 2222L, 3333L, 4444L, true, "#FF00FF", "foo", "bar", "https://foo.bar/image", "https://foo.foo", NotificationClickAction.APP_OPEN, "foo://bar", 4L, 5L, 6L, "PUSH_MESSAGE", true)
+        val bothDiffData = NotificationData(
+            "hackle",
+            "4",
+            333L,
+            333L,
+            1111L,
+            2222L,
+            3333L,
+            4444L,
+            true,
+            "#FF00FF",
+            "foo",
+            "bar",
+            "https://foo.bar/image",
+            "https://foo.foo",
+            NotificationClickAction.APP_OPEN,
+            "foo://bar",
+            4L,
+            5L,
+            6L,
+            "PUSH_MESSAGE",
+            true
+        )
         manager.onNotificationDataReceived(bothDiffData, 4L)
 
         verify(exactly = 1) {
@@ -111,7 +233,29 @@ class NotificationManagerTest {
     fun `save notification data if workspace fetcher returns null`() {
         every { workspaceFetcher.fetch() } returns null
 
-        val data = NotificationData("abcd1234", 111L, 222L, 1111L, 2222L, 3333L, 4444L, true, "#FF00FF", "foo", "bar", "https://foo.bar/image", "https://foo.foo", NotificationClickAction.APP_OPEN, "foo://bar", null, null, null, null, true)
+        val data = NotificationData(
+            "hackle",
+            "abcd1234",
+            111L,
+            222L,
+            1111L,
+            2222L,
+            3333L,
+            4444L,
+            true,
+            "#FF00FF",
+            "foo",
+            "bar",
+            "https://foo.bar/image",
+            "https://foo.foo",
+            NotificationClickAction.APP_OPEN,
+            "foo://bar",
+            null,
+            null,
+            null,
+            null,
+            true
+        )
         manager.onNotificationDataReceived(data, 1L)
 
         verify { core wasNot called }

--- a/hackle-android-sdk/src/test/java/io/hackle/android/mock/MockBundle.kt
+++ b/hackle-android-sdk/src/test/java/io/hackle/android/mock/MockBundle.kt
@@ -1,0 +1,47 @@
+package io.hackle.android.mock
+
+import android.os.Bundle
+import io.mockk.every
+import io.mockk.mockk
+
+object MockBundle {
+    fun create(map: Map<String, Any?>): Bundle {
+        val bundle = mockk<Bundle>()
+        for ((key, value) in map) {
+            when (value) {
+                is Boolean -> {
+                    every { bundle.getBoolean(key) } returns value
+                    every { bundle.getBoolean(key, any()) } returns value
+                }
+                is String -> {
+                    every { bundle.getString(key) } returns value
+                    every { bundle.getString(key, any()) } returns value
+                }
+                is Number -> {
+                    every { bundle.getByte(key) } returns value.toByte()
+                    every { bundle.getByte(key, any()) } returns value.toByte()
+
+                    every { bundle.getChar(key) } returns value.toChar()
+                    every { bundle.getChar(key, any()) } returns value.toChar()
+
+                    every { bundle.getShort(key) } returns value.toShort()
+                    every { bundle.getShort(key, any()) } returns value.toShort()
+
+                    every { bundle.getInt(key) } returns value.toInt()
+                    every { bundle.getInt(key, any()) } returns value.toInt()
+
+                    every { bundle.getLong(key) } returns value.toLong()
+                    every { bundle.getLong(key, any()) } returns value.toLong()
+
+                    every { bundle.getFloat(key) } returns value.toFloat()
+                    every { bundle.getFloat(key, any()) } returns value.toFloat()
+
+                    every { bundle.getDouble(key) } returns value.toDouble()
+                    every { bundle.getDouble(key, any()) } returns value.toDouble()
+                }
+                else -> throw UnsupportedOperationException("Type is not supported.")
+            }
+        }
+        return bundle
+    }
+}

--- a/hackle-android-sdk/src/test/java/io/hackle/android/ui/notification/NotificationDataTest.kt
+++ b/hackle-android-sdk/src/test/java/io/hackle/android/ui/notification/NotificationDataTest.kt
@@ -3,6 +3,7 @@ package io.hackle.android.ui.notification
 import android.content.Intent
 import android.os.Bundle
 import io.hackle.android.internal.utils.json.toJson
+import io.hackle.android.mock.MockBundle
 import io.mockk.every
 import io.mockk.mockk
 import org.hamcrest.CoreMatchers.`is`
@@ -35,7 +36,7 @@ class NotificationDataTest {
             "link" to "foo://bar",
             "debug" to true
         )
-        val bundle = mockBundleOf(mapOf(
+        val bundle = MockBundle.create(mapOf(
             "google.message_id" to "abcd1234",
             "google.sent_time" to 1234567890L,
             "hackle" to map.toJson(),
@@ -70,7 +71,7 @@ class NotificationDataTest {
             "workspaceId" to 1111,
             "environmentId" to 2222
         )
-        val bundle = mockBundleOf(mapOf(
+        val bundle = MockBundle.create(mapOf(
             "google.message_id" to "abcd1234",
             "google.sent_time" to 0L,
             "hackle" to map.toJson()
@@ -100,7 +101,7 @@ class NotificationDataTest {
     @Test
     fun `should return null if hackle string is empty`() {
         val intent = mockk<Intent>()
-        val bundle = mockBundleOf(mapOf(
+        val bundle = MockBundle.create(mapOf(
             "google.message_id" to "abcd1234",
             "google.sent_time" to 1234567890
         ))
@@ -128,7 +129,7 @@ class NotificationDataTest {
             "link" to "foo://bar",
             "debug" to true
         )
-        val bundle = mockBundleOf(mapOf(
+        val bundle = MockBundle.create(mapOf(
             "google.message_id" to "abcd1234",
             "google.sent_time" to 1234567890,
             "hackle" to map.toJson()
@@ -157,7 +158,7 @@ class NotificationDataTest {
             "link" to "foo://bar",
             "debug" to true
         )
-        val bundle = mockBundleOf(mapOf(
+        val bundle = MockBundle.create(mapOf(
             "google.message_id" to "abcd1234",
             "google.sent_time" to 1234567890,
             "hackle" to map.toJson()
@@ -165,45 +166,5 @@ class NotificationDataTest {
         every { intent.extras } returns bundle
 
         assertNull(NotificationData.from(intent))
-    }
-
-    private fun mockBundleOf(map: Map<String, Any?>): Bundle {
-        val bundle = mockk<Bundle>()
-        for ((key, value) in map) {
-            when (value) {
-                is Boolean -> {
-                    every { bundle.getBoolean(key) } returns value
-                    every { bundle.getBoolean(key, any()) } returns value
-                }
-                is String -> {
-                    every { bundle.getString(key) } returns value
-                    every { bundle.getString(key, any()) } returns value
-                }
-                is Number -> {
-                    every { bundle.getByte(key) } returns value.toByte()
-                    every { bundle.getByte(key, any()) } returns value.toByte()
-
-                    every { bundle.getChar(key) } returns value.toChar()
-                    every { bundle.getChar(key, any()) } returns value.toChar()
-
-                    every { bundle.getShort(key) } returns value.toShort()
-                    every { bundle.getShort(key, any()) } returns value.toShort()
-
-                    every { bundle.getInt(key) } returns value.toInt()
-                    every { bundle.getInt(key, any()) } returns value.toInt()
-
-                    every { bundle.getLong(key) } returns value.toLong()
-                    every { bundle.getLong(key, any()) } returns value.toLong()
-
-                    every { bundle.getFloat(key) } returns value.toFloat()
-                    every { bundle.getFloat(key, any()) } returns value.toFloat()
-
-                    every { bundle.getDouble(key) } returns value.toDouble()
-                    every { bundle.getDouble(key, any()) } returns value.toDouble()
-                }
-                else -> throw UnsupportedOperationException("Type is not supported.")
-            }
-        }
-        return bundle
     }
 }

--- a/hackle-android-sdk/src/test/java/io/hackle/android/ui/notification/NotificationDataTest.kt
+++ b/hackle-android-sdk/src/test/java/io/hackle/android/ui/notification/NotificationDataTest.kt
@@ -19,6 +19,7 @@ class NotificationDataTest {
     fun `parse notification data`() {
         val intent = mockk<Intent>()
         val map = mapOf<String, Any>(
+            "channelId" to "hackle_heads_up_notification",
             "workspaceId" to 1111,
             "environmentId" to 2222,
             "pushMessageId" to 3333,
@@ -43,7 +44,8 @@ class NotificationDataTest {
 
         val result = NotificationData.from(intent)
         assertNotNull(result)
-        assertThat(result!!.messageId, `is`("abcd1234"))
+        assertThat(result!!.channelId, `is`("hackle_heads_up_notification"))
+        assertThat(result.messageId, `is`("abcd1234"))
         assertThat(result.workspaceId, `is`(1111L))
         assertThat(result.environmentId, `is`(2222L))
         assertThat(result.pushMessageId, `is`(3333L))
@@ -64,6 +66,7 @@ class NotificationDataTest {
     fun `should parse notification data even though optional fields are empty`() {
         val intent = mockk<Intent>()
         val map = mapOf<String, Any>(
+            "channelId" to "hackle_heads_up_notification",
             "workspaceId" to 1111,
             "environmentId" to 2222
         )
@@ -76,7 +79,8 @@ class NotificationDataTest {
 
         val result = NotificationData.from(intent)
         assertNotNull(result)
-        assertThat(result!!.messageId, `is`("abcd1234"))
+        assertThat(result!!.channelId, `is`("hackle_heads_up_notification"))
+        assertThat(result.messageId, `is`("abcd1234"))
         assertThat(result.workspaceId, `is`(1111L))
         assertThat(result.environmentId, `is`(2222L))
         assertNull(result.pushMessageId)
@@ -109,6 +113,7 @@ class NotificationDataTest {
     fun `should return null if workspace id is empty`() {
         val intent = mockk<Intent>()
         val map = mapOf<String, Any>(
+            "channelId" to "hackle_heads_up_notification",
             "environmentId" to 2222,
             "pushMessageId" to 3333,
             "pushMessageKey" to 4444,
@@ -137,6 +142,7 @@ class NotificationDataTest {
     fun `should return null if environment id is empty`() {
         val intent = mockk<Intent>()
         val map = mapOf<String, Any>(
+            "channelId" to "hackle_heads_up_notification",
             "workspaceId" to 1111,
             "pushMessageId" to 3333,
             "pushMessageKey" to 4444,

--- a/hackle-android-sdk/src/test/java/io/hackle/android/ui/notification/NotificationFactoryTest.kt
+++ b/hackle-android-sdk/src/test/java/io/hackle/android/ui/notification/NotificationFactoryTest.kt
@@ -325,68 +325,6 @@ class NotificationFactoryTest {
         assertFalse(notificationData.debug)
     }
 
-    @Test
-    fun `hasLargeImage should return true when largeImageUrl is not null or empty`() {
-        // Given
-        val hackleData = mapOf(
-            KEY_WORKSPACE_ID to 12345,
-            KEY_ENVIRONMENT_ID to 67890,
-            KEY_LARGE_IMAGE_URL to "https://example.com/large.jpg"
-        )
-
-        val intent = createMockIntent("msg_123", hackleData.toJson())
-        val notificationData = NotificationData.from(intent)
-
-        // When & Then
-        assertTrue(notificationData!!.hasLargeImage())
-    }
-
-    @Test
-    fun `hasLargeImage should return false when largeImageUrl is null`() {
-        // Given
-        val hackleData = mapOf(
-            KEY_WORKSPACE_ID to 12345,
-            KEY_ENVIRONMENT_ID to 67890
-        )
-
-        val intent = createMockIntent("msg_123", hackleData.toJson())
-        val notificationData = NotificationData.from(intent)
-
-        // When & Then
-        assertFalse(notificationData!!.hasLargeImage())
-    }
-
-    @Test
-    fun `hasThumbnailImage should return true when thumbnailImageUrl is not null or empty`() {
-        // Given
-        val hackleData = mapOf(
-            KEY_WORKSPACE_ID to 12345,
-            KEY_ENVIRONMENT_ID to 67890,
-            KEY_THUMBNAIL_IMAGE_URL to "https://example.com/thumb.jpg"
-        )
-
-        val intent = createMockIntent("msg_123", hackleData.toJson())
-        val notificationData = NotificationData.from(intent)
-
-        // When & Then
-        assertTrue(notificationData!!.hasThumbnailImage())
-    }
-
-    @Test
-    fun `hasThumbnailImage should return false when thumbnailImageUrl is null`() {
-        // Given
-        val hackleData = mapOf(
-            KEY_WORKSPACE_ID to 12345,
-            KEY_ENVIRONMENT_ID to 67890
-        )
-
-        val intent = createMockIntent("msg_123", hackleData.toJson())
-        val notificationData = NotificationData.from(intent)
-
-        // When & Then
-        assertFalse(notificationData!!.hasThumbnailImage())
-    }
-
     private fun createMockIntent(messageId: String, hackleJson: String): Intent {
         val bundle = MockBundle.create(
             mapOf(
@@ -398,7 +336,4 @@ class NotificationFactoryTest {
         every { intent.extras } returns bundle
         return intent
     }
-
-    private fun NotificationData.hasLargeImage() = largeImageUrl != null && largeImageUrl.isNotEmpty()
-    private fun NotificationData.hasThumbnailImage() = thumbnailImageUrl != null && thumbnailImageUrl.isNotEmpty()
 }

--- a/hackle-android-sdk/src/test/java/io/hackle/android/ui/notification/NotificationFactoryTest.kt
+++ b/hackle-android-sdk/src/test/java/io/hackle/android/ui/notification/NotificationFactoryTest.kt
@@ -1,0 +1,404 @@
+package io.hackle.android.ui.notification
+
+import android.content.Intent
+import android.os.Bundle
+import io.hackle.android.internal.utils.json.toJson
+import io.hackle.android.mock.MockBundle
+import io.hackle.android.ui.notification.Constants.DEFAULT_NOTIFICATION_CHANNEL_ID
+import io.hackle.android.ui.notification.Constants.KEY_BODY
+import io.hackle.android.ui.notification.Constants.KEY_CAMPAIGN_TYPE
+import io.hackle.android.ui.notification.Constants.KEY_CHANNEL_ID
+import io.hackle.android.ui.notification.Constants.KEY_CLICK_ACTION
+import io.hackle.android.ui.notification.Constants.KEY_COLOR_FILTER
+import io.hackle.android.ui.notification.Constants.KEY_DEBUG
+import io.hackle.android.ui.notification.Constants.KEY_ENVIRONMENT_ID
+import io.hackle.android.ui.notification.Constants.KEY_HACKLE
+import io.hackle.android.ui.notification.Constants.KEY_JOURNEY_ID
+import io.hackle.android.ui.notification.Constants.KEY_JOURNEY_KEY
+import io.hackle.android.ui.notification.Constants.KEY_JOURNEY_NODE_ID
+import io.hackle.android.ui.notification.Constants.KEY_LARGE_IMAGE_URL
+import io.hackle.android.ui.notification.Constants.KEY_LINK
+import io.hackle.android.ui.notification.Constants.KEY_MESSAGE_ID
+import io.hackle.android.ui.notification.Constants.KEY_PUSH_MESSAGE_DELIVERY_ID
+import io.hackle.android.ui.notification.Constants.KEY_PUSH_MESSAGE_EXECUTION_ID
+import io.hackle.android.ui.notification.Constants.KEY_PUSH_MESSAGE_ID
+import io.hackle.android.ui.notification.Constants.KEY_PUSH_MESSAGE_KEY
+import io.hackle.android.ui.notification.Constants.KEY_SHOW_FOREGROUND
+import io.hackle.android.ui.notification.Constants.KEY_THUMBNAIL_IMAGE_URL
+import io.hackle.android.ui.notification.Constants.KEY_TITLE
+import io.hackle.android.ui.notification.Constants.KEY_WORKSPACE_ID
+import io.mockk.every
+import io.mockk.mockk
+import org.hamcrest.CoreMatchers.`is`
+import org.hamcrest.MatcherAssert.assertThat
+import org.junit.Assert.assertFalse
+import org.junit.Assert.assertNotNull
+import org.junit.Assert.assertNull
+import org.junit.Assert.assertTrue
+import org.junit.Test
+
+class NotificationFactoryTest {
+    @Test
+    fun `parse notification data with all fields`() {
+        // Given
+        val hackleData = mapOf(
+            KEY_CHANNEL_ID to "test_channel",
+            KEY_WORKSPACE_ID to 12345,
+            KEY_ENVIRONMENT_ID to 67890,
+            KEY_PUSH_MESSAGE_ID to 11111,
+            KEY_PUSH_MESSAGE_KEY to 22222,
+            KEY_PUSH_MESSAGE_EXECUTION_ID to 33333,
+            KEY_PUSH_MESSAGE_DELIVERY_ID to 44444,
+            KEY_SHOW_FOREGROUND to true,
+            KEY_COLOR_FILTER to "#FF0000",
+            KEY_TITLE to "Test Title",
+            KEY_BODY to "Test Body",
+            KEY_THUMBNAIL_IMAGE_URL to "https://example.com/thumb.jpg",
+            KEY_LARGE_IMAGE_URL to "https://example.com/large.jpg",
+            KEY_CLICK_ACTION to "DEEP_LINK",
+            KEY_LINK to "https://example.com/deeplink",
+            KEY_JOURNEY_ID to 55555,
+            KEY_JOURNEY_KEY to 66666,
+            KEY_JOURNEY_NODE_ID to 77777,
+            KEY_CAMPAIGN_TYPE to "PUSH",
+            KEY_DEBUG to true
+        )
+
+        val intent = createMockIntent("msg_123", hackleData.toJson())
+
+        // When
+        val notificationData = NotificationData.from(intent)
+
+        // Then
+        assertNotNull(notificationData)
+        assertThat(notificationData!!.channelId, `is`("test_channel"))
+        assertThat(notificationData.messageId, `is`("msg_123"))
+        assertThat(notificationData.workspaceId, `is`(12345L))
+        assertThat(notificationData.environmentId, `is`(67890L))
+        assertThat(notificationData.pushMessageId, `is`(11111L))
+        assertThat(notificationData.pushMessageKey, `is`(22222L))
+        assertThat(notificationData.pushMessageExecutionId, `is`(33333L))
+        assertThat(notificationData.pushMessageDeliveryId, `is`(44444L))
+        assertTrue(notificationData.showForeground)
+        assertThat(notificationData.iconColorFilter, `is`("#FF0000"))
+        assertThat(notificationData.title, `is`("Test Title"))
+        assertThat(notificationData.body, `is`("Test Body"))
+        assertThat(notificationData.thumbnailImageUrl, `is`("https://example.com/thumb.jpg"))
+        assertThat(notificationData.largeImageUrl, `is`("https://example.com/large.jpg"))
+        assertThat(notificationData.clickAction, `is`(NotificationClickAction.DEEP_LINK))
+        assertThat(notificationData.link, `is`("https://example.com/deeplink"))
+        assertThat(notificationData.journeyId, `is`(55555L))
+        assertThat(notificationData.journeyKey, `is`(66666L))
+        assertThat(notificationData.journeyNodeId, `is`(77777L))
+        assertThat(notificationData.campaignType, `is`("PUSH"))
+        assertTrue(notificationData.debug)
+    }
+
+    @Test
+    fun `parse notification data with minimal required fields`() {
+        // Given
+        val hackleData = mapOf(
+            KEY_WORKSPACE_ID to 12345,
+            KEY_ENVIRONMENT_ID to 67890,
+            KEY_TITLE to "Test Title",
+            KEY_BODY to "Test Body"
+        )
+
+        val intent = createMockIntent("msg_234", hackleData.toJson())
+
+        // When
+        val notificationData = NotificationData.from(intent)
+
+        // Then
+        assertNotNull(notificationData)
+        assertThat(notificationData!!.channelId, `is`(DEFAULT_NOTIFICATION_CHANNEL_ID))
+        assertThat(notificationData.messageId, `is`("msg_234"))
+        assertThat(notificationData.workspaceId, `is`(12345L))
+        assertThat(notificationData.environmentId, `is`(67890L))
+        assertNull(notificationData.pushMessageId)
+        assertNull(notificationData.pushMessageKey)
+        assertNull(notificationData.pushMessageExecutionId)
+        assertNull(notificationData.pushMessageDeliveryId)
+        assertFalse(notificationData.showForeground)
+        assertNull(notificationData.iconColorFilter)
+        assertThat(notificationData.title, `is`("Test Title"))
+        assertThat(notificationData.body, `is`("Test Body"))
+        assertNull(notificationData.thumbnailImageUrl)
+        assertNull(notificationData.largeImageUrl)
+        assertThat(notificationData.clickAction, `is`(NotificationClickAction.APP_OPEN))
+        assertNull(notificationData.link)
+        assertNull(notificationData.journeyId)
+        assertNull(notificationData.journeyKey)
+        assertNull(notificationData.journeyNodeId)
+        assertNull(notificationData.campaignType)
+        assertFalse(notificationData.debug)
+    }
+
+    @Test
+    fun `parse notification data with default channel id when not provided`() {
+        // Given
+        val hackleData = mapOf(
+            KEY_WORKSPACE_ID to 12345,
+            KEY_ENVIRONMENT_ID to 67890
+        )
+
+        val intent = createMockIntent("msg_345", hackleData.toJson())
+
+        // When
+        val notificationData = NotificationData.from(intent)
+
+        // Then
+        assertNotNull(notificationData)
+        assertThat(notificationData!!.channelId, `is`(DEFAULT_NOTIFICATION_CHANNEL_ID))
+    }
+
+    @Test
+    fun `parse notification data with default click action when not provided`() {
+        // Given
+        val hackleData = mapOf(
+            KEY_WORKSPACE_ID to 12345,
+            KEY_ENVIRONMENT_ID to 67890
+        )
+
+        val intent = createMockIntent("msg_123", hackleData.toJson())
+
+        // When
+        val notificationData = NotificationData.from(intent)
+
+        // Then
+        assertNotNull(notificationData)
+        assertThat(notificationData!!.clickAction, `is`(NotificationClickAction.APP_OPEN))
+    }
+
+    @Test
+    fun `parse notification data with various click actions`() {
+        // Given
+        val hackleData = mapOf(
+            KEY_WORKSPACE_ID to 12345,
+            KEY_ENVIRONMENT_ID to 67890,
+            KEY_CLICK_ACTION to "DEEP_LINK"
+        )
+
+        val intent = createMockIntent("msg_123", hackleData.toJson())
+
+        // When
+        val notificationData = NotificationData.from(intent)
+
+        // Then
+        assertNotNull(notificationData)
+        assertThat(notificationData!!.clickAction, `is`(NotificationClickAction.DEEP_LINK))
+    }
+
+    @Test
+    fun `parse notification data should return null when intent extras is null`() {
+        // Given
+        val intent = mockk<Intent>()
+        every { intent.extras } returns null
+
+        // When
+        val notificationData = NotificationData.from(intent)
+
+        // Then
+        assertNull(notificationData)
+    }
+
+    @Test
+    fun `parse notification data should return null when hackle key is missing`() {
+        // Given
+        val bundle = Bundle().apply {
+            putString(KEY_MESSAGE_ID, "msg_123")
+        }
+        val intent = mockk<Intent>()
+        every { intent.extras } returns bundle
+
+        // When
+        val notificationData = NotificationData.from(intent)
+
+        // Then
+        assertNull(notificationData)
+    }
+
+    @Test
+    fun `parse notification data should return null when message id is missing`() {
+        // Given
+        val hackleData = mapOf(
+            KEY_WORKSPACE_ID to 12345,
+            KEY_ENVIRONMENT_ID to 67890
+        )
+        val bundle = Bundle().apply {
+            putString(KEY_HACKLE, hackleData.toJson())
+        }
+        val intent = mockk<Intent>()
+        every { intent.extras } returns bundle
+
+        // When
+        val notificationData = NotificationData.from(intent)
+
+        // Then
+        assertNull(notificationData)
+    }
+
+    @Test
+    fun `parse notification data should return null when workspace id is missing`() {
+        // Given
+        val hackleData = mapOf(
+            KEY_ENVIRONMENT_ID to 67890
+        )
+
+        val intent = createMockIntent("msg_123", hackleData.toJson())
+
+        // When
+        val notificationData = NotificationData.from(intent)
+
+        // Then
+        assertNull(notificationData)
+    }
+
+    @Test
+    fun `parse notification data should return null when environment id is missing`() {
+        // Given
+        val hackleData = mapOf(
+            KEY_WORKSPACE_ID to 12345
+        )
+
+        val intent = createMockIntent("msg_123", hackleData.toJson())
+
+        // When
+        val notificationData = NotificationData.from(intent)
+
+        // Then
+        assertNull(notificationData)
+    }
+
+    @Test
+    fun `parse notification data should return null when hackle json is invalid`() {
+        // Given
+        val intent = createMockIntent("msg_123", "invalid_json")
+
+        // When
+        val notificationData = NotificationData.from(intent)
+
+        // Then
+        assertNull(notificationData)
+    }
+
+    @Test
+    fun `parse notification data with number fields as different types`() {
+        val hackleData = mapOf(
+            KEY_WORKSPACE_ID to 12345.0, 
+            KEY_ENVIRONMENT_ID to 67890L, 
+            KEY_PUSH_MESSAGE_ID to 11111, 
+            KEY_JOURNEY_ID to 55555.0f
+        )
+
+        val intent = createMockIntent("msg_123", hackleData.toJson())
+
+        // When
+        val notificationData = NotificationData.from(intent)
+
+        // Then
+        assertNotNull(notificationData)
+        assertThat(notificationData!!.workspaceId, `is`(12345L))
+        assertThat(notificationData.environmentId, `is`(67890L))
+        assertThat(notificationData.pushMessageId, `is`(11111L))
+        assertThat(notificationData.journeyId, `is`(55555L))
+    }
+
+    @Test
+    fun `parse notification data with boolean fields`() {
+        // Given
+        val hackleData = mapOf(
+            KEY_WORKSPACE_ID to 12345,
+            KEY_ENVIRONMENT_ID to 67890,
+            KEY_SHOW_FOREGROUND to true,
+            KEY_DEBUG to false
+        )
+
+        val intent = createMockIntent("msg_123", hackleData.toJson())
+
+        // When
+        val notificationData = NotificationData.from(intent)
+
+        // Then
+        assertNotNull(notificationData)
+        assertTrue(notificationData!!.showForeground)
+        assertFalse(notificationData.debug)
+    }
+
+    @Test
+    fun `hasLargeImage should return true when largeImageUrl is not null or empty`() {
+        // Given
+        val hackleData = mapOf(
+            KEY_WORKSPACE_ID to 12345,
+            KEY_ENVIRONMENT_ID to 67890,
+            KEY_LARGE_IMAGE_URL to "https://example.com/large.jpg"
+        )
+
+        val intent = createMockIntent("msg_123", hackleData.toJson())
+        val notificationData = NotificationData.from(intent)
+
+        // When & Then
+        assertTrue(notificationData!!.hasLargeImage())
+    }
+
+    @Test
+    fun `hasLargeImage should return false when largeImageUrl is null`() {
+        // Given
+        val hackleData = mapOf(
+            KEY_WORKSPACE_ID to 12345,
+            KEY_ENVIRONMENT_ID to 67890
+        )
+
+        val intent = createMockIntent("msg_123", hackleData.toJson())
+        val notificationData = NotificationData.from(intent)
+
+        // When & Then
+        assertFalse(notificationData!!.hasLargeImage())
+    }
+
+    @Test
+    fun `hasThumbnailImage should return true when thumbnailImageUrl is not null or empty`() {
+        // Given
+        val hackleData = mapOf(
+            KEY_WORKSPACE_ID to 12345,
+            KEY_ENVIRONMENT_ID to 67890,
+            KEY_THUMBNAIL_IMAGE_URL to "https://example.com/thumb.jpg"
+        )
+
+        val intent = createMockIntent("msg_123", hackleData.toJson())
+        val notificationData = NotificationData.from(intent)
+
+        // When & Then
+        assertTrue(notificationData!!.hasThumbnailImage())
+    }
+
+    @Test
+    fun `hasThumbnailImage should return false when thumbnailImageUrl is null`() {
+        // Given
+        val hackleData = mapOf(
+            KEY_WORKSPACE_ID to 12345,
+            KEY_ENVIRONMENT_ID to 67890
+        )
+
+        val intent = createMockIntent("msg_123", hackleData.toJson())
+        val notificationData = NotificationData.from(intent)
+
+        // When & Then
+        assertFalse(notificationData!!.hasThumbnailImage())
+    }
+
+    private fun createMockIntent(messageId: String, hackleJson: String): Intent {
+        val bundle = MockBundle.create(
+            mapOf(
+                KEY_MESSAGE_ID to messageId,
+                KEY_HACKLE to hackleJson
+            )
+        )
+        val intent = mockk<Intent>()
+        every { intent.extras } returns bundle
+        return intent
+    }
+
+    private fun NotificationData.hasLargeImage() = largeImageUrl != null && largeImageUrl.isNotEmpty()
+    private fun NotificationData.hasThumbnailImage() = thumbnailImageUrl != null && thumbnailImageUrl.isNotEmpty()
+}


### PR DESCRIPTION
## 개요
푸시 수신 시 데이터에 명시된 채널로 푸시를 전달하는 기능을 추가했습니다.

## 작업 내용
### NotificationData에 channelId를 추가했습니다.
- `null`이나 `""`이면 default 채널을 이용합니다. 

### createNotification 로직을 수정했습니다.
- notificationData의 channel id로 푸시를 전달합니다.
- 존재하지 않는 채널인 경우 아래와 같이 동작합니다.
  - default나 high 채널인 경우 채널을 새로 생성합니다.
  - 위 2개에 해당되지 않는 경우 default 채널을 이용합니다.
- push priority를 삭제했습니다.
  - 서버에서 priority를 전해주지 않아 삭제했습니다.
  - 푸시 수신 시 푸시 채널의 priority를 사용합니다.
 
### high 채널을 추가했습니다.
- `IMPORTANCE_HIGH`인 채널 입니다.
- 푸시 수신 시 Heads-up notifications이 표시됩니다.

## 참고
| channel name | channel id |
| -- | -- |
| **default** | `io_hackle_android_default_notification_channel_id` |
| **high** | `io_hackle_android_high_notification_channel_id` |