### PR TITLE
support back button on in-app message

### DIFF
--- a/hackle-android-sdk/src/main/java/io/hackle/android/HackleApp.kt
+++ b/hackle-android-sdk/src/main/java/io/hackle/android/HackleApp.kt
@@ -306,6 +306,10 @@ class HackleApp internal constructor(
     fun setInAppMessageListener(listener: HackleInAppMessageListener?) {
         InAppMessageUi.instance.setListener(listener)
     }
+    
+    fun setBackButtonDismissesInAppMessageView(isDismisses: Boolean) {
+        InAppMessageUi.instance.setBackButtonDismisses(isDismisses)
+    }
 
     @JvmOverloads
     fun fetch(callback: Runnable? = null) {

--- a/hackle-android-sdk/src/main/java/io/hackle/android/HackleApp.kt
+++ b/hackle-android-sdk/src/main/java/io/hackle/android/HackleApp.kt
@@ -307,6 +307,16 @@ class HackleApp internal constructor(
         InAppMessageUi.instance.setListener(listener)
     }
     
+    /**
+     * Sets whether the back button should dismiss the in-app message view.
+     * 
+     * When enabled (default), pressing the device's back button will close 
+     * the currently displayed in-app message. When disabled, back button 
+     * presses will be ignored by the in-app message view.
+     * 
+     * @param isDismisses true if the back button should dismiss the in-app message, 
+     *                    false otherwise. Default is true.
+     */
     fun setBackButtonDismissesInAppMessageView(isDismisses: Boolean) {
         InAppMessageUi.instance.setBackButtonDismisses(isDismisses)
     }

--- a/hackle-android-sdk/src/main/java/io/hackle/android/ui/core/ViewExtensions.kt
+++ b/hackle-android-sdk/src/main/java/io/hackle/android/ui/core/ViewExtensions.kt
@@ -1,6 +1,7 @@
 package io.hackle.android.ui.core
 
 import android.app.Activity
+import android.view.View
 import io.hackle.sdk.core.internal.log.Logger
 
 private val log = Logger("io.hackle.android.ViewExtensions")
@@ -10,5 +11,14 @@ internal fun Activity.setActivityRequestedOrientation(requestedOrientation: Int)
         this.requestedOrientation = requestedOrientation
     } catch (e: Throwable) {
         log.error { "Failed to set requested orientation[$localClassName]: $e" }
+    }
+}
+
+internal fun View.setFocusableInTouchModeAndRequestFocus() {
+    try {
+        this.isFocusableInTouchMode = true
+        this.requestFocus()
+    } catch (e: Throwable) {
+        log.error { "Failed to set focusable in touch mode and request focus on view: $e" }
     }
 }

--- a/hackle-android-sdk/src/main/java/io/hackle/android/ui/inappmessage/InAppMessageUi.kt
+++ b/hackle-android-sdk/src/main/java/io/hackle/android/ui/inappmessage/InAppMessageUi.kt
@@ -37,6 +37,9 @@ internal class InAppMessageUi(
     private var customListener: HackleInAppMessageListener? = null
     val listener get() = customListener ?: defaultListener
 
+    private var _isBackButtonDismisses: Boolean = true
+    val isBackButtonDismisses get() = _isBackButtonDismisses
+
     private val opening = AtomicBoolean(false)
 
     override fun present(context: InAppMessagePresentationContext) {
@@ -73,6 +76,10 @@ internal class InAppMessageUi(
 
     fun setListener(listener: HackleInAppMessageListener?) {
         customListener = listener
+    }
+    
+    fun setBackButtonDismisses(backButtonDismissesInAppMessage: Boolean) {
+        _isBackButtonDismisses = backButtonDismissesInAppMessage
     }
 
     fun closeCurrent() {

--- a/hackle-android-sdk/src/main/java/io/hackle/android/ui/inappmessage/layout/view/InAppMessageView.kt
+++ b/hackle-android-sdk/src/main/java/io/hackle/android/ui/inappmessage/layout/view/InAppMessageView.kt
@@ -3,6 +3,7 @@ package io.hackle.android.ui.inappmessage.layout.view
 import android.app.Activity
 import android.content.Context
 import android.util.AttributeSet
+import android.view.KeyEvent
 import android.view.View.OnClickListener
 import android.widget.RelativeLayout
 import androidx.core.view.WindowInsetsCompat
@@ -33,6 +34,14 @@ internal abstract class InAppMessageView @JvmOverloads constructor(
 
     val inAppMessage: InAppMessage get() = context.inAppMessage
     val message: InAppMessage.Message get() = context.message
+
+    override fun onKeyDown(keyCode: Int, event: KeyEvent?): Boolean {
+        if (keyCode == KeyEvent.KEYCODE_BACK) {
+            controller.close()
+            return true
+        }
+        return super.onKeyDown(keyCode, event)
+    }
 
     fun setController(controller: InAppMessageViewController) {
         _controller = controller

--- a/hackle-android-sdk/src/main/java/io/hackle/android/ui/inappmessage/layout/view/InAppMessageView.kt
+++ b/hackle-android-sdk/src/main/java/io/hackle/android/ui/inappmessage/layout/view/InAppMessageView.kt
@@ -38,7 +38,7 @@ internal abstract class InAppMessageView @JvmOverloads constructor(
 
     override fun onKeyDown(keyCode: Int, event: KeyEvent?): Boolean {
         if (keyCode == KeyEvent.KEYCODE_BACK && InAppMessageUi.instance.isBackButtonDismisses) {
-            controller.close()
+            close()
             return true
         }
         return super.onKeyDown(keyCode, event)

--- a/hackle-android-sdk/src/main/java/io/hackle/android/ui/inappmessage/layout/view/InAppMessageView.kt
+++ b/hackle-android-sdk/src/main/java/io/hackle/android/ui/inappmessage/layout/view/InAppMessageView.kt
@@ -9,6 +9,7 @@ import android.widget.RelativeLayout
 import androidx.core.view.WindowInsetsCompat
 import io.hackle.android.internal.inappmessage.present.presentation.InAppMessagePresentationContext
 import io.hackle.android.ui.inappmessage.InAppMessageLifecycle
+import io.hackle.android.ui.inappmessage.InAppMessageUi
 import io.hackle.android.ui.inappmessage.event.InAppMessageEvent
 import io.hackle.android.ui.inappmessage.layout.InAppMessageAnimator
 import io.hackle.android.ui.inappmessage.layout.InAppMessageLayout
@@ -36,7 +37,7 @@ internal abstract class InAppMessageView @JvmOverloads constructor(
     val message: InAppMessage.Message get() = context.message
 
     override fun onKeyDown(keyCode: Int, event: KeyEvent?): Boolean {
-        if (keyCode == KeyEvent.KEYCODE_BACK) {
+        if (keyCode == KeyEvent.KEYCODE_BACK && InAppMessageUi.instance.isBackButtonDismisses) {
             controller.close()
             return true
         }

--- a/hackle-android-sdk/src/main/java/io/hackle/android/ui/inappmessage/layout/view/InAppMessageViewController.kt
+++ b/hackle-android-sdk/src/main/java/io/hackle/android/ui/inappmessage/layout/view/InAppMessageViewController.kt
@@ -40,6 +40,7 @@ internal class InAppMessageViewController(
         startAnimation(view.openAnimator, completion = {
             handle(InAppMessageEvent.Impression)
             lifecycle(AFTER_OPEN)
+            view.setFocusableInTouchModeAndRequestFocus()
         })
     }
 
@@ -69,7 +70,6 @@ internal class InAppMessageViewController(
         parent.addView(view)
         ViewCompat.requestApplyInsets(parent)
         view.setActivity(activity)
-        view.setFocusableInTouchModeAndRequestFocus()
     }
 
     private fun removeView() {

--- a/hackle-android-sdk/src/main/java/io/hackle/android/ui/inappmessage/layout/view/InAppMessageViewController.kt
+++ b/hackle-android-sdk/src/main/java/io/hackle/android/ui/inappmessage/layout/view/InAppMessageViewController.kt
@@ -70,11 +70,7 @@ internal class InAppMessageViewController(
         parent.addView(view)
         ViewCompat.requestApplyInsets(parent)
         view.setActivity(activity)
-        
-        // TODO: 특정 인앱만 뒤로가기 동작 시킬지
-        if (view.context.message.layout.displayType == InAppMessage.DisplayType.MODAL || view.context.message.layout.displayType == InAppMessage.DisplayType.BOTTOM_SHEET) {
-            view.setFocusableInTouchModeAndRequestFocus()
-        }
+        view.setFocusableInTouchModeAndRequestFocus()
     }
 
     private fun removeView() {

--- a/hackle-android-sdk/src/main/java/io/hackle/android/ui/inappmessage/layout/view/InAppMessageViewController.kt
+++ b/hackle-android-sdk/src/main/java/io/hackle/android/ui/inappmessage/layout/view/InAppMessageViewController.kt
@@ -14,7 +14,6 @@ import io.hackle.android.ui.inappmessage.event.InAppMessageEvent
 import io.hackle.android.ui.inappmessage.layout.InAppMessageAnimator
 import io.hackle.android.ui.inappmessage.layout.InAppMessageLayout.State
 import io.hackle.sdk.core.internal.log.Logger
-import io.hackle.sdk.core.model.InAppMessage
 import java.util.concurrent.atomic.AtomicReference
 
 

--- a/hackle-android-sdk/src/main/java/io/hackle/android/ui/inappmessage/layout/view/InAppMessageViewController.kt
+++ b/hackle-android-sdk/src/main/java/io/hackle/android/ui/inappmessage/layout/view/InAppMessageViewController.kt
@@ -7,12 +7,14 @@ import android.view.ViewGroup
 import androidx.core.view.ViewCompat
 import io.hackle.android.internal.inappmessage.present.presentation.InAppMessagePresentationContext
 import io.hackle.android.ui.core.setActivityRequestedOrientation
+import io.hackle.android.ui.core.setFocusableInTouchModeAndRequestFocus
 import io.hackle.android.ui.inappmessage.*
 import io.hackle.android.ui.inappmessage.InAppMessageLifecycle.*
 import io.hackle.android.ui.inappmessage.event.InAppMessageEvent
 import io.hackle.android.ui.inappmessage.layout.InAppMessageAnimator
 import io.hackle.android.ui.inappmessage.layout.InAppMessageLayout.State
 import io.hackle.sdk.core.internal.log.Logger
+import io.hackle.sdk.core.model.InAppMessage
 import java.util.concurrent.atomic.AtomicReference
 
 
@@ -68,6 +70,11 @@ internal class InAppMessageViewController(
         parent.addView(view)
         ViewCompat.requestApplyInsets(parent)
         view.setActivity(activity)
+        
+        // TODO: 특정 인앱만 뒤로가기 동작 시킬지
+        if (view.context.message.layout.displayType == InAppMessage.DisplayType.MODAL || view.context.message.layout.displayType == InAppMessage.DisplayType.BOTTOM_SHEET) {
+            view.setFocusableInTouchModeAndRequestFocus()
+        }
     }
 
     private fun removeView() {

--- a/hackle-android-sdk/src/test/java/io/hackle/android/ui/inappmessage/InAppMessageUiTest.kt
+++ b/hackle-android-sdk/src/test/java/io/hackle/android/ui/inappmessage/InAppMessageUiTest.kt
@@ -144,4 +144,28 @@ class InAppMessageUiTest {
             controller.open(activity)
         }
     }
+
+    @Test
+    fun `when setBackButtonDismisses is called with true then isBackButtonDismisses should return true`() {
+        // when
+        sut.setBackButtonDismisses(true)
+
+        // then
+        assert(sut.isBackButtonDismisses)
+    }
+
+    @Test
+    fun `when setBackButtonDismisses is called with false then isBackButtonDismisses should return false`() {
+        // when
+        sut.setBackButtonDismisses(false)
+
+        // then
+        assert(!sut.isBackButtonDismisses)
+    }
+
+    @Test
+    fun `default value of isBackButtonDismisses should be true`() {
+        // then
+        assert(sut.isBackButtonDismisses)
+    }
 }

--- a/hackle-android-sdk/src/test/java/io/hackle/android/ui/inappmessage/layout/view/InAppMessageViewTest.kt
+++ b/hackle-android-sdk/src/test/java/io/hackle/android/ui/inappmessage/layout/view/InAppMessageViewTest.kt
@@ -1,0 +1,80 @@
+package io.hackle.android.ui.inappmessage.layout.view
+
+import android.app.Activity
+import android.view.KeyEvent
+import io.hackle.android.internal.inappmessage.present.presentation.InAppMessagePresentationContext
+import io.hackle.android.support.InAppMessages
+import io.hackle.android.ui.inappmessage.InAppMessageUi
+import io.hackle.android.ui.inappmessage.layout.InAppMessageAnimator
+import io.mockk.*
+import org.junit.Before
+import org.junit.Test
+
+class InAppMessageViewTest {
+
+    private lateinit var view: TestInAppMessageView
+    private lateinit var controller: InAppMessageViewController
+    private lateinit var activity: Activity
+    private lateinit var context: InAppMessagePresentationContext
+
+    @Before
+    fun before() {
+        activity = mockk(relaxed = true)
+        controller = mockk(relaxed = true)
+        context = InAppMessages.context()
+        
+        view = TestInAppMessageView(activity)
+        view.setController(controller)
+        view.setContext(context)
+        view.setActivity(activity)
+        
+        mockkObject(InAppMessageUi)
+        every { InAppMessageUi.instance } returns mockk(relaxed = true)
+    }
+
+    @Test
+    fun `when back button is pressed and isBackButtonDismisses is true then controller close should be called`() {
+        // given
+        every { InAppMessageUi.instance.isBackButtonDismisses } returns true
+
+        // when
+        val result = view.onKeyDown(KeyEvent.KEYCODE_BACK, null)
+
+        // then
+        verify { controller.close() }
+        assert(result)
+    }
+
+    @Test
+    fun `when back button is pressed and isBackButtonDismisses is false then controller close should not be called`() {
+        // given
+        every { InAppMessageUi.instance.isBackButtonDismisses } returns false
+
+        // when
+        val result = view.onKeyDown(KeyEvent.KEYCODE_BACK, null)
+
+        // then
+        verify(exactly = 0) { controller.close() }
+        assert(!result) // should call super.onKeyDown which returns false
+    }
+
+    @Test
+    fun `when non-back button is pressed then controller close should not be called`() {
+        // given
+        every { InAppMessageUi.instance.isBackButtonDismisses } returns true
+
+        // when
+        val result = view.onKeyDown(KeyEvent.KEYCODE_HOME, null)
+
+        // then
+        verify(exactly = 0) { controller.close() }
+        assert(!result) // should call super.onKeyDown which returns false
+    }
+
+    // Test implementation of InAppMessageView for testing purposes
+    private class TestInAppMessageView(context: android.content.Context) : InAppMessageView(context) {
+        override val openAnimator: InAppMessageAnimator? = null
+        override val closeAnimator: InAppMessageAnimator? = null
+        override fun configure() {}
+    }
+}


### PR DESCRIPTION
## 개요
인앱 메시지가 표시되었을 떄 뒤로가기 버튼을 누르면 In-App Message가 닫히는 기능을 추가했습니다.

## 작업내용
### 인앱 메시지가 표시 중 뒤로가기 버튼을 누르면 인앱메시지를 닫습니다.

### `setBackButtonDismissesInAppMessageView` 함수를 추가했습니다.
- 기본적으로 인앱 메시지 표시 중 뒤로가기 버튼을 누르면 인앱 메시지가 닫힙니다.
- setBackButtonDismissesInAppMessageView 함수를 true/false로 호출하는 것으로 뒤로 가기 버튼을 통해 인앱 메시지 닫힘 여부를 결정할 수 있습니다

#### 특정 인앱만 뒤로가기 버튼으로 닫기 비활성화 예제
```kotlin
Hackle.app.setInAppMessageListener(object: HackleInAppMessageListener {
    override fun beforeInAppMessageOpen(inAppMessage: HackleInAppMessage) {
        if(inAppMessage.key == 218L) { // 비활성화 할 인앱 메시지 키
            Hackle.app.setBackButtonDismissesInAppMessageView(false)
        }
    }

    override fun afterInAppMessageOpen(inAppMessage: HackleInAppMessage) {
    }

    override fun beforeInAppMessageClose(inAppMessage: HackleInAppMessage) {
    }

    override fun afterInAppMessageClose(inAppMessage: HackleInAppMessage) {
        Hackle.app.setBackButtonDismissesInAppMessageView(true)
    }

    override fun onInAppMessageClick(
        inAppMessage: HackleInAppMessage,
        view: HackleInAppMessageView,
        action: HackleInAppMessageAction
    ): Boolean {
         return false
    }
})
```