### PR TITLE
in app close when activity destoryed

### DIFF
--- a/hackle-android-sdk/src/main/java/io/hackle/android/HackleApps.kt
+++ b/hackle-android-sdk/src/main/java/io/hackle/android/HackleApps.kt
@@ -367,7 +367,6 @@ internal object HackleApps {
             eventHandler = inAppMessageEventHandler,
             imageLoader = imageLoader
         )
-        
 
         val inAppMessageRecorder = InAppMessageRecorder(
             storage = inAppMessageImpressionStorage

--- a/hackle-android-sdk/src/main/java/io/hackle/android/HackleApps.kt
+++ b/hackle-android-sdk/src/main/java/io/hackle/android/HackleApps.kt
@@ -367,6 +367,7 @@ internal object HackleApps {
             eventHandler = inAppMessageEventHandler,
             imageLoader = imageLoader
         )
+        
 
         val inAppMessageRecorder = InAppMessageRecorder(
             storage = inAppMessageImpressionStorage
@@ -514,6 +515,7 @@ internal object HackleApps {
             lifecycleManager.addListener(screenManager, order = Ordered.HIGHEST)
         }
         lifecycleManager.addListener(engagementManager, order = Ordered.HIGHEST + 1)
+        lifecycleManager.addListener(inAppMessageUi, order = Ordered.LOWEST)
         lifecycleManager.addListener(userExplorer, order = Ordered.LOWEST - 1)
         lifecycleManager.registerTo(context)
 

--- a/hackle-android-sdk/src/main/java/io/hackle/android/ui/inappmessage/InAppMessageController.kt
+++ b/hackle-android-sdk/src/main/java/io/hackle/android/ui/inappmessage/InAppMessageController.kt
@@ -32,8 +32,8 @@ internal interface InAppMessageController {
 
     /**
      * Closes the [InAppMessageLayout].
+     * @param withAnimation Whether to animate the closing process.
      */
-    
     fun close(withAnimation: Boolean = true)
 }
 

--- a/hackle-android-sdk/src/main/java/io/hackle/android/ui/inappmessage/InAppMessageController.kt
+++ b/hackle-android-sdk/src/main/java/io/hackle/android/ui/inappmessage/InAppMessageController.kt
@@ -33,9 +33,8 @@ internal interface InAppMessageController {
     /**
      * Closes the [InAppMessageLayout].
      */
-    fun close()
     
-    fun closeIfAttachedActivityDestroyed(activity: Activity)
+    fun close(withAnimation: Boolean = true)
 }
 
 internal fun InAppMessageController.handle(event: InAppMessageEvent) {

--- a/hackle-android-sdk/src/main/java/io/hackle/android/ui/inappmessage/InAppMessageController.kt
+++ b/hackle-android-sdk/src/main/java/io/hackle/android/ui/inappmessage/InAppMessageController.kt
@@ -34,6 +34,8 @@ internal interface InAppMessageController {
      * Closes the [InAppMessageLayout].
      */
     fun close()
+    
+    fun close(activity: Activity)
 }
 
 internal fun InAppMessageController.handle(event: InAppMessageEvent) {

--- a/hackle-android-sdk/src/main/java/io/hackle/android/ui/inappmessage/InAppMessageController.kt
+++ b/hackle-android-sdk/src/main/java/io/hackle/android/ui/inappmessage/InAppMessageController.kt
@@ -35,7 +35,7 @@ internal interface InAppMessageController {
      */
     fun close()
     
-    fun close(activity: Activity)
+    fun closeIfAttachedActivityDestroyed(activity: Activity)
 }
 
 internal fun InAppMessageController.handle(event: InAppMessageEvent) {

--- a/hackle-android-sdk/src/main/java/io/hackle/android/ui/inappmessage/InAppMessageUi.kt
+++ b/hackle-android-sdk/src/main/java/io/hackle/android/ui/inappmessage/InAppMessageUi.kt
@@ -92,11 +92,12 @@ internal class InAppMessageUi(
         activity: Activity,
         timestamp: Long
     ) {
-        return when (lifecycle) {
-            DESTROYED -> {
-                currentMessageController?.closeIfAttachedActivityDestroyed(activity) ?: return
-            }
-            CREATED, STARTED, RESUMED, PAUSED, STOPPED -> Unit
+        if (lifecycle != DESTROYED) {
+            return
+        }
+        val controller = currentMessageController ?: return
+        if (controller.layout.activity == activity) {
+            controller.close(false)
         }
     }
 

--- a/hackle-android-sdk/src/main/java/io/hackle/android/ui/inappmessage/InAppMessageUi.kt
+++ b/hackle-android-sdk/src/main/java/io/hackle/android/ui/inappmessage/InAppMessageUi.kt
@@ -19,6 +19,7 @@ import io.hackle.android.ui.inappmessage.layout.InAppMessageLayout
 import io.hackle.sdk.common.HackleInAppMessageListener
 import io.hackle.sdk.core.internal.log.Logger
 import io.hackle.sdk.core.internal.scheduler.Scheduler
+import io.hackle.sdk.core.internal.utils.tryClose
 import java.util.concurrent.atomic.AtomicBoolean
 import java.util.concurrent.atomic.AtomicReference
 
@@ -94,7 +95,7 @@ internal class InAppMessageUi(
     ) {
         return when (lifecycle) {
             DESTROYED -> {
-                closeCurrent()
+                currentMessageController?.close(activity) ?: return
             }
             CREATED, STARTED, RESUMED, PAUSED, STOPPED -> Unit
         }

--- a/hackle-android-sdk/src/main/java/io/hackle/android/ui/inappmessage/InAppMessageUi.kt
+++ b/hackle-android-sdk/src/main/java/io/hackle/android/ui/inappmessage/InAppMessageUi.kt
@@ -4,6 +4,14 @@ import android.app.Activity
 import io.hackle.android.internal.inappmessage.present.presentation.InAppMessagePresentationContext
 import io.hackle.android.internal.inappmessage.present.presentation.InAppMessagePresenter
 import io.hackle.android.internal.lifecycle.ActivityProvider
+import io.hackle.android.internal.lifecycle.Lifecycle
+import io.hackle.android.internal.lifecycle.Lifecycle.CREATED
+import io.hackle.android.internal.lifecycle.Lifecycle.DESTROYED
+import io.hackle.android.internal.lifecycle.Lifecycle.PAUSED
+import io.hackle.android.internal.lifecycle.Lifecycle.RESUMED
+import io.hackle.android.internal.lifecycle.Lifecycle.STARTED
+import io.hackle.android.internal.lifecycle.Lifecycle.STOPPED
+import io.hackle.android.internal.lifecycle.LifecycleListener
 import io.hackle.android.internal.task.TaskExecutors.runOnUiThread
 import io.hackle.android.ui.core.ImageLoader
 import io.hackle.android.ui.inappmessage.event.InAppMessageEventHandler
@@ -29,7 +37,7 @@ internal class InAppMessageUi(
     val scheduler: Scheduler,
     val eventHandler: InAppMessageEventHandler,
     val imageLoader: ImageLoader,
-) : InAppMessagePresenter {
+) : InAppMessagePresenter, LifecycleListener {
 
     private val _currentMessageController = AtomicReference<InAppMessageController>()
     val currentMessageController: InAppMessageController? get() = _currentMessageController.get()
@@ -77,6 +85,19 @@ internal class InAppMessageUi(
 
     fun closeCurrent() {
         _currentMessageController.set(null)
+    }
+
+    override fun onLifecycle(
+        lifecycle: Lifecycle,
+        activity: Activity,
+        timestamp: Long
+    ) {
+        return when (lifecycle) {
+            DESTROYED -> {
+                closeCurrent()
+            }
+            CREATED, STARTED, RESUMED, PAUSED, STOPPED -> Unit
+        }
     }
 
     companion object {

--- a/hackle-android-sdk/src/main/java/io/hackle/android/ui/inappmessage/InAppMessageUi.kt
+++ b/hackle-android-sdk/src/main/java/io/hackle/android/ui/inappmessage/InAppMessageUi.kt
@@ -19,7 +19,6 @@ import io.hackle.android.ui.inappmessage.layout.InAppMessageLayout
 import io.hackle.sdk.common.HackleInAppMessageListener
 import io.hackle.sdk.core.internal.log.Logger
 import io.hackle.sdk.core.internal.scheduler.Scheduler
-import io.hackle.sdk.core.internal.utils.tryClose
 import java.util.concurrent.atomic.AtomicBoolean
 import java.util.concurrent.atomic.AtomicReference
 
@@ -95,7 +94,7 @@ internal class InAppMessageUi(
     ) {
         return when (lifecycle) {
             DESTROYED -> {
-                currentMessageController?.close(activity) ?: return
+                currentMessageController?.closeIfAttachedActivityDestroyed(activity) ?: return
             }
             CREATED, STARTED, RESUMED, PAUSED, STOPPED -> Unit
         }

--- a/hackle-android-sdk/src/main/java/io/hackle/android/ui/inappmessage/layout/activity/InAppMessageActivityController.kt
+++ b/hackle-android-sdk/src/main/java/io/hackle/android/ui/inappmessage/layout/activity/InAppMessageActivityController.kt
@@ -52,8 +52,8 @@ internal class InAppMessageActivityController private constructor(
         ui.closeCurrent()
     }
     
-    override fun close(activity: Activity) {
-        // nothing to do
+    override fun closeIfAttachedActivityDestroyed(activity: Activity) {
+        log.debug { "InAppMessageActivityController ignores activity destroy (activity=${activity.javaClass.simpleName})" }
     }
 
     companion object {

--- a/hackle-android-sdk/src/main/java/io/hackle/android/ui/inappmessage/layout/activity/InAppMessageActivityController.kt
+++ b/hackle-android-sdk/src/main/java/io/hackle/android/ui/inappmessage/layout/activity/InAppMessageActivityController.kt
@@ -51,7 +51,7 @@ internal class InAppMessageActivityController private constructor(
         messageActivity?.get()?.activity?.finish()
         ui.closeCurrent()
     }
-    
+
     override fun closeIfAttachedActivityDestroyed(activity: Activity) {
         log.debug { "InAppMessageActivityController ignores activity destroy (activity=${activity.javaClass.simpleName})" }
     }

--- a/hackle-android-sdk/src/main/java/io/hackle/android/ui/inappmessage/layout/activity/InAppMessageActivityController.kt
+++ b/hackle-android-sdk/src/main/java/io/hackle/android/ui/inappmessage/layout/activity/InAppMessageActivityController.kt
@@ -41,7 +41,7 @@ internal class InAppMessageActivityController private constructor(
         handle(InAppMessageEvent.Impression)
     }
 
-    override fun close() {
+    override fun close(withAnimation: Boolean) {
         if (!_state.compareAndSet(State.OPENED, State.CLOSED)) {
             log.debug { "InAppMessage is already close (key=${context.inAppMessage.key})" }
             return
@@ -50,10 +50,6 @@ internal class InAppMessageActivityController private constructor(
         handle(InAppMessageEvent.Close)
         messageActivity?.get()?.activity?.finish()
         ui.closeCurrent()
-    }
-
-    override fun closeIfAttachedActivityDestroyed(activity: Activity) {
-        log.debug { "InAppMessageActivityController ignores activity destroy (activity=${activity.javaClass.simpleName})" }
     }
 
     companion object {

--- a/hackle-android-sdk/src/main/java/io/hackle/android/ui/inappmessage/layout/activity/InAppMessageActivityController.kt
+++ b/hackle-android-sdk/src/main/java/io/hackle/android/ui/inappmessage/layout/activity/InAppMessageActivityController.kt
@@ -51,6 +51,10 @@ internal class InAppMessageActivityController private constructor(
         messageActivity?.get()?.activity?.finish()
         ui.closeCurrent()
     }
+    
+    override fun close(activity: Activity) {
+        // nothing to do
+    }
 
     companion object {
         private val log = Logger<InAppMessageActivityController>()

--- a/hackle-android-sdk/src/main/java/io/hackle/android/ui/inappmessage/layout/view/InAppMessageViewController.kt
+++ b/hackle-android-sdk/src/main/java/io/hackle/android/ui/inappmessage/layout/view/InAppMessageViewController.kt
@@ -41,7 +41,7 @@ internal class InAppMessageViewController(
             lifecycle(AFTER_OPEN)
         })
     }
-    
+
     override fun close(withAnimation: Boolean) {
         if (!_state.compareAndSet(State.OPENED, State.CLOSED)) {
             log.debug { "InAppMessage is already close (key=${context.inAppMessage.key})" }
@@ -49,14 +49,14 @@ internal class InAppMessageViewController(
         }
 
         lifecycle(BEFORE_CLOSE)
-        handle(InAppMessageEvent.Close)
-
         if (withAnimation) {
             startAnimation(view.closeAnimator, completion = {
+                handle(InAppMessageEvent.Close)
                 removeView()
                 lifecycle(AFTER_CLOSE)
             })
         } else {
+            handle(InAppMessageEvent.Close)
             removeView()
             lifecycle(AFTER_CLOSE)
         }
@@ -81,7 +81,7 @@ internal class InAppMessageViewController(
 
         val parent = view.parent as? ViewGroup
         parent?.removeView(view)
-        
+
         ui.closeCurrent()
     }
 

--- a/hackle-android-sdk/src/main/java/io/hackle/android/ui/inappmessage/layout/view/InAppMessageViewController.kt
+++ b/hackle-android-sdk/src/main/java/io/hackle/android/ui/inappmessage/layout/view/InAppMessageViewController.kt
@@ -55,7 +55,7 @@ internal class InAppMessageViewController(
                 close(withAnimation = false) {
                     ui.closeCurrent()
                 }
-        }
+            }
     }
 
     private fun close(withAnimation: Boolean, onComplete: () -> Unit) {
@@ -63,7 +63,7 @@ internal class InAppMessageViewController(
             log.debug { "InAppMessage is already close (key=${context.inAppMessage.key})" }
             return
         }
-        
+
         lifecycle(BEFORE_CLOSE)
         handle(InAppMessageEvent.Close)
 

--- a/hackle-android-sdk/src/main/java/io/hackle/android/ui/inappmessage/layout/view/InAppMessageViewController.kt
+++ b/hackle-android-sdk/src/main/java/io/hackle/android/ui/inappmessage/layout/view/InAppMessageViewController.kt
@@ -56,6 +56,22 @@ internal class InAppMessageViewController(
         })
     }
 
+    override fun close(activity: Activity) {
+        if (!_state.compareAndSet(State.OPENED, State.CLOSED)) {
+            log.debug { "InAppMessage is already close (key=${context.inAppMessage.key})" }
+            return
+        }
+        
+        view.activity
+            ?.takeIf { it == activity }
+            ?.let { 
+                lifecycle(BEFORE_CLOSE)
+                handle(InAppMessageEvent.Close)
+                ui.closeCurrent()
+                lifecycle(AFTER_CLOSE)
+        }
+    }
+
     private fun lifecycle(lifecycle: InAppMessageLifecycle) {
         view.publish(lifecycle)
         ui.listener.onLifecycle(lifecycle, context.inAppMessage)

--- a/hackle-android-sdk/src/main/java/io/hackle/android/ui/inappmessage/layout/view/InAppMessageViewController.kt
+++ b/hackle-android-sdk/src/main/java/io/hackle/android/ui/inappmessage/layout/view/InAppMessageViewController.kt
@@ -41,24 +41,8 @@ internal class InAppMessageViewController(
             lifecycle(AFTER_OPEN)
         })
     }
-
-    override fun close() {
-        close(withAnimation = true) {
-            removeView()
-        }
-    }
-
-    override fun closeIfAttachedActivityDestroyed(activity: Activity) {
-        view.activity
-            ?.takeIf { it == activity }
-            ?.let {
-                close(withAnimation = false) {
-                    ui.closeCurrent()
-                }
-            }
-    }
-
-    private fun close(withAnimation: Boolean, onComplete: () -> Unit) {
+    
+    override fun close(withAnimation: Boolean) {
         if (!_state.compareAndSet(State.OPENED, State.CLOSED)) {
             log.debug { "InAppMessage is already close (key=${context.inAppMessage.key})" }
             return
@@ -69,11 +53,11 @@ internal class InAppMessageViewController(
 
         if (withAnimation) {
             startAnimation(view.closeAnimator, completion = {
-                onComplete()
+                removeView()
                 lifecycle(AFTER_CLOSE)
             })
         } else {
-            onComplete()
+            removeView()
             lifecycle(AFTER_CLOSE)
         }
     }
@@ -95,8 +79,9 @@ internal class InAppMessageViewController(
     private fun removeView() {
         unlockScreenOrientation()
 
-        val parent = view.parent as? ViewGroup ?: return
-        parent.removeView(view)
+        val parent = view.parent as? ViewGroup
+        parent?.removeView(view)
+        
         ui.closeCurrent()
     }
 


### PR DESCRIPTION
## 개요
인앱 매시지가 표시되고 있는 엑티비티가 destroyed 되었을 때 동작을 수정했습니다.

## 작업 내용
### InAppMessageUI에 LifecycleListener 를 추가했습니다.
- activity `DESTROYED`가 호출되면 InAppMessageController의  `close`를 호출합니다.

### InAppMessageController에 close에 withAnimation 파라미터를 추가했습니다.
- 엑티비티가 사라질 때 애니메이션도 동작 안하면서 complition이 호출안되는 문제가 있어 `DESTORYED`에서 호출되는 close는 애니메이션을 동작 안시키게 수정했습니다.
