### PR TITLE
modify engagement

### DIFF
--- a/hackle-android-sdk/src/main/java/io/hackle/android/internal/engagement/EngagementManager.kt
+++ b/hackle-android-sdk/src/main/java/io/hackle/android/internal/engagement/EngagementManager.kt
@@ -18,7 +18,6 @@ internal class EngagementManager(
     private val screenManager: ScreenManager,
     private val minimumEngagementDurationMillis: Long
 ) : ApplicationListenerRegistry<EngagementListener>(), ScreenListener, LifecycleListener {
-
     private val _lastEngagementTime = AtomicReference<Long?>()
     val lastEngagementTime: Long? get() = _lastEngagementTime.get()
 
@@ -27,7 +26,7 @@ internal class EngagementManager(
     }
 
     private fun endEngagement(screen: Screen, timestamp: Long) {
-        val startTimestamp = _lastEngagementTime.getAndSet(timestamp) ?: return
+        val startTimestamp = _lastEngagementTime.getAndSet(null) ?: return
 
         val engagementDurationMillis = timestamp - startTimestamp
         if (engagementDurationMillis < minimumEngagementDurationMillis) {

--- a/hackle-android-sdk/src/test/java/io/hackle/android/internal/core/listener/ApplicationListenerRegistryTest.kt
+++ b/hackle-android-sdk/src/test/java/io/hackle/android/internal/core/listener/ApplicationListenerRegistryTest.kt
@@ -88,5 +88,5 @@ internal class ApplicationListenerRegistryTest {
 
     private class TestApplicationListenerRegistry : ApplicationListenerRegistry<TestApplicationListener>()
 
-    private interface TestApplicationListener : ApplicationListener
+    internal interface TestApplicationListener : ApplicationListener
 }

--- a/hackle-android-sdk/src/test/java/io/hackle/android/internal/engagement/EngagementManagerTest.kt
+++ b/hackle-android-sdk/src/test/java/io/hackle/android/internal/engagement/EngagementManagerTest.kt
@@ -121,4 +121,114 @@ class EngagementManagerTest {
             )
         }
     }
+
+    @Test
+    fun `multiple start without end - only last start is considered`() {
+        // given
+        val screen = Screen("name", "class")
+
+        // when - multiple start engagements
+        sut.onScreenStarted(null, screen, mockk(), 100)
+        sut.onScreenStarted(screen, screen, mockk(), 200)
+        sut.onScreenStarted(screen, screen, mockk(), 300)
+        sut.onScreenEnded(screen, mockk(), 500)
+
+        // then - engagement duration calculated from last start (300ms)
+        verify(exactly = 1) {
+            listener.onEngagement(
+                withArg {
+                    expectThat(it) {
+                        get { durationMillis } isEqualTo 200
+                    }
+                },
+                any(),
+                any()
+            )
+        }
+    }
+
+    @Test
+    fun `multiple end without start - no engagement published`() {
+        // given
+        val screen = Screen("name", "class")
+
+        // when - multiple end engagements without start
+        sut.onScreenEnded(screen, mockk(), 100)
+        sut.onScreenEnded(screen, mockk(), 200)
+        sut.onScreenEnded(screen, mockk(), 300)
+
+        // then - no engagement published
+        verify { listener wasNot Called }
+    }
+
+    @Test
+    fun `start-end-end sequence - second end does nothing`() {
+        // given
+        val screen = Screen("name", "class")
+
+        // when
+        sut.onScreenStarted(null, screen, mockk(), 100)
+        sut.onScreenEnded(screen, mockk(), 300) // first end - should publish
+        sut.onScreenEnded(screen, mockk(), 400) // second end - should do nothing
+
+        // then - only one engagement published
+        verify(exactly = 1) {
+            listener.onEngagement(
+                withArg {
+                    expectThat(it) {
+                        get { durationMillis } isEqualTo 200
+                    }
+                },
+                any(),
+                any()
+            )
+        }
+    }
+
+    @Test
+    fun `start-end-start-end sequence - two engagements published`() {
+        // given
+        val screen1 = Screen("screen1", "class1")
+        val screen2 = Screen("screen2", "class2")
+
+        // when
+        sut.onScreenStarted(null, screen1, mockk(), 100)
+        sut.onScreenEnded(screen1, mockk(), 300) // first engagement
+        sut.onScreenStarted(screen1, screen2, mockk(), 400)
+        sut.onScreenEnded(screen2, mockk(), 600) // second engagement
+
+        // then - two engagements published
+        verify(exactly = 2) {
+            listener.onEngagement(any(), any(), any())
+        }
+    }
+
+    @Test
+    fun `lastEngagementTime cleared after endEngagement`() {
+        // given
+        val screen = Screen("name", "class")
+
+        // when
+        sut.onScreenStarted(null, screen, mockk(), 100)
+        expectThat(sut.lastEngagementTime).isEqualTo(100L)
+
+        sut.onScreenEnded(screen, mockk(), 300)
+
+        // then
+        expectThat(sut.lastEngagementTime).isEqualTo(null)
+    }
+
+    @Test
+    fun `lastEngagementTime cleared after endEngagement even if not published`() {
+        // given
+        val screen = Screen("name", "class")
+
+        // when - engagement too short to be published
+        sut.onScreenStarted(null, screen, mockk(), 100)
+        sut.onScreenEnded(screen, mockk(), 150) // duration 50ms < minimum 100ms
+
+        // then - lastEngagementTime should still be cleared
+        expectThat(sut.lastEngagementTime).isEqualTo(null)
+        verify { listener wasNot Called }
+    }
 }


### PR DESCRIPTION
## 개요
`$engagement` 발생 조건을 수정하였습니다.

## 작업 내용
### AS-IS
- endEngagement가 호출될 때마다 `$engagement` 이벤트가 발생합니다.

### TO-BE
- endEngagement가 발생할 때 `_lastEngagementTime`을 null로 초기화 합니다.
- startEngagement 호출 후 endEngagement가 호출될 때만 `$engagement` 이벤트가 발생합니다.
