### PR TITLE
feature: bump Android SDK to 21/34 and migrate OkHttp to 4.12.0

### DIFF
--- a/.github/workflows/kdoc-deploy.yml
+++ b/.github/workflows/kdoc-deploy.yml
@@ -34,10 +34,10 @@ jobs:
       - name: Set up Gradle
         uses: gradle/gradle-build-action@v2
         with:
-          gradle-version: 7.2
-      
+          gradle-version: 8.7
+
       - name: Generate KDoc
-        run: gradle :hackle-android-sdk:dokkaHtml
+        run: ./gradlew :hackle-android-sdk:dokkaHtml
       
       - name: Setup Pages
         uses: actions/configure-pages@v4

--- a/.github/workflows/publish.yml
+++ b/.github/workflows/publish.yml
@@ -21,7 +21,7 @@ jobs:
       - name: Set up Gradle
         uses: gradle/gradle-build-action@v2
         with:
-          gradle-version: 7.2
+          gradle-version: 8.7
 
       - name: Set up Snapshot version for Workflow Dispatch
         if: ${{ github.event_name == 'workflow_dispatch'}}
@@ -72,7 +72,7 @@ jobs:
           fi
 
       - name: Publish
-        run: gradle :hackle-android-sdk:clean :hackle-android-sdk:build publishToSonatype closeAndReleaseSonatypeStagingRepository --info --configure-on-demand
+        run: ./gradlew :hackle-android-sdk:clean :hackle-android-sdk:build publishToSonatype closeAndReleaseSonatypeStagingRepository --info --configure-on-demand
         env:
           SONATYPE_USERNAME: ${{ secrets.SONATYPE_USERNAME }}
           SONATYPE_PASSWORD: ${{ secrets.SONATYPE_PASSWORD }}

--- a/.github/workflows/test.yml
+++ b/.github/workflows/test.yml
@@ -17,12 +17,12 @@ jobs:
       - name: Set up Gradle
         uses: gradle/gradle-build-action@v2
         with:
-          gradle-version: 7.2
+          gradle-version: 8.7
           cache-read-only: false
           gradle-home-cache-cleanup: true
 
       - name: Test
-        run: gradle :hackle-android-sdk:test :hackle-android-sdk:coverageReport --quiet --no-daemon --warning-mode=none
+        run: ./gradlew :hackle-android-sdk:test :hackle-android-sdk:coverageReport --quiet --no-daemon --warning-mode=none
         env:
           ANDROID_SDK_SUPPRESS_WARNINGS: true
           ANDROID_SUPPRESS_ALL_WARNINGS: true

--- a/TesterApp/build.gradle
+++ b/TesterApp/build.gradle
@@ -12,7 +12,7 @@ android {
 
     defaultConfig {
         applicationId "io.hackle.android.sdk.tester"
-        minSdkVersion 16
+        minSdkVersion 21
         targetSdkVersion 35
         versionCode 1
         versionName "1.0"

--- a/hackle-android-sdk/build.gradle
+++ b/hackle-android-sdk/build.gradle
@@ -12,11 +12,11 @@ version = sdk_version
 
 android {
     namespace "io.hackle.android"
-    compileSdkVersion 31
+    compileSdkVersion 34
 
     defaultConfig {
-        minSdkVersion 16
-        targetSdkVersion 31
+        minSdkVersion 21
+        targetSdkVersion 34
         versionCode 1
         versionName version
 
@@ -67,10 +67,10 @@ dependencies {
     }
 
 
-    implementation 'com.squareup.okhttp3:okhttp:3.12.2'
+    implementation 'com.squareup.okhttp3:okhttp:4.12.0'
     implementation "com.google.android.gms:play-services-base:17.3.0"
     implementation "com.google.code.gson:gson:2.8.9"
-    implementation 'androidx.core:core-ktx:1.3.2'
+    implementation 'androidx.core:core-ktx:1.13.1'
     implementation "androidx.recyclerview:recyclerview:1.2.1"
     implementation 'androidx.webkit:webkit:1.4.0'
 

--- a/hackle-android-sdk/src/main/java/io/hackle/android/HackleApp.kt
+++ b/hackle-android-sdk/src/main/java/io/hackle/android/HackleApp.kt
@@ -1,18 +1,14 @@
 package io.hackle.android
 
-import android.annotation.SuppressLint
-import android.annotation.TargetApi
 import android.app.Activity
 import android.content.Context
 import android.content.Intent
-import android.os.Build
 import android.webkit.WebView
 import io.hackle.android.internal.HackleAppCore
 import io.hackle.android.internal.activity.lifecycle.ActivityLifecycleManager
 import io.hackle.android.internal.application.lifecycle.ApplicationLifecycleManager
 import io.hackle.android.internal.context.HackleAppContext
 import io.hackle.android.internal.invocator.web.HackleJavascriptInterface
-import io.hackle.android.internal.model.AndroidBuild
 import io.hackle.android.internal.model.Sdk
 import io.hackle.android.internal.remoteconfig.HackleRemoteConfigImpl
 import io.hackle.android.ui.explorer.base.HackleUserExplorerService
@@ -306,16 +302,8 @@ class HackleApp internal constructor(
      * @param webView  Target [WebView]. MUST NOT be null
      * @param webViewConfig the [HackleWebViewConfig] that contains WebView configuration
      */
-    @SuppressLint("UseRequiresApi")
-    @TargetApi(Build.VERSION_CODES.JELLY_BEAN_MR1)
     @JvmOverloads
     fun setWebViewBridge(webView: WebView, webViewConfig: HackleWebViewConfig = HackleWebViewConfig.DEFAULT) {
-        if (AndroidBuild.sdkVersion() < Build.VERSION_CODES.JELLY_BEAN_MR1) {
-            throw IllegalStateException(
-                "HackleApp.setJavascriptInterface should not be called with minSdkVersion < 17 for security reasons: " +
-                        "JavaScript can use reflection to manipulate application"
-            )
-        }
         val javascriptInterface = HackleJavascriptInterface(this, webViewConfig)
         javascriptInterface.addTo(webView)
     }

--- a/hackle-android-sdk/src/main/java/io/hackle/android/internal/devtools/DevToolsApi.kt
+++ b/hackle-android-sdk/src/main/java/io/hackle/android/internal/devtools/DevToolsApi.kt
@@ -7,7 +7,7 @@ import io.hackle.android.internal.model.Sdk
 import io.hackle.android.internal.utils.json.toJson
 import okhttp3.OkHttpClient
 import okhttp3.Request
-import okhttp3.RequestBody
+import okhttp3.RequestBody.Companion.toRequestBody
 
 internal class DevToolsApi(
     private val sdk: Sdk,
@@ -42,11 +42,11 @@ internal class DevToolsApi(
     private fun execute(method: String, path: String, requestBody: Any) {
         val request = Request.Builder()
             .url("$url$path")
-            .method(method, RequestBody.create(CONTENT_TYPE_APPLICATION_JSON, requestBody.toJson()))
+            .method(method, requestBody.toJson().toRequestBody(CONTENT_TYPE_APPLICATION_JSON))
             .header("X-HACKLE-API-KEY", sdk.key)
             .build()
         val response = httpClient.newCall(request).execute()
-        response.use { require(it.isSuccessful) { "[${it.code()}] $method $path" } }
+        response.use { require(it.isSuccessful) { "[${it.code}] $method $path" } }
     }
 }
 

--- a/hackle-android-sdk/src/main/java/io/hackle/android/internal/event/EventDispatcher.kt
+++ b/hackle-android-sdk/src/main/java/io/hackle/android/internal/event/EventDispatcher.kt
@@ -5,11 +5,11 @@ import io.hackle.android.internal.database.workspace.EventEntity.Status.PENDING
 import io.hackle.android.internal.database.repository.EventRepository
 import io.hackle.android.internal.monitoring.metric.ApiCallMetrics
 import io.hackle.sdk.core.internal.log.Logger
-import okhttp3.HttpUrl
-import okhttp3.MediaType
+import okhttp3.HttpUrl.Companion.toHttpUrl
+import okhttp3.MediaType.Companion.toMediaType
 import okhttp3.OkHttpClient
 import okhttp3.Request
-import okhttp3.RequestBody
+import okhttp3.RequestBody.Companion.toRequestBody
 import okhttp3.Response
 import java.util.concurrent.Executor
 
@@ -21,7 +21,7 @@ internal class EventDispatcher(
     private val httpClient: OkHttpClient,
     private val eventBackoffController: UserEventBackoffController,
 ) {
-    private val dispatchEndpoint = HttpUrl.get(baseEventUri + EVENT_DISPATCH_PATH)
+    private val dispatchEndpoint = (baseEventUri + EVENT_DISPATCH_PATH).toHttpUrl()
 
     fun dispatch(events: List<EventEntity>) {
         try {
@@ -59,7 +59,7 @@ internal class EventDispatcher(
         }
 
         private fun dispatch() {
-            val requestBody = RequestBody.create(CONTENT_TYPE, events.toBody())
+            val requestBody = events.toBody().toRequestBody(CONTENT_TYPE)
             val request = Request.Builder()
                 .url(dispatchEndpoint)
                 .post(requestBody)
@@ -80,10 +80,10 @@ internal class EventDispatcher(
         }
 
         private fun handleResponse(response: Response): Boolean {
-            when (response.code()) {
+            when (response.code) {
                 in 200..299 -> delete(events)
                 in 400..499 -> delete(events)
-                else -> throw IllegalStateException("Http status code: ${response.code()}")
+                else -> throw IllegalStateException("Http status code: ${response.code}")
             }
             return response.isSuccessful
         }
@@ -111,7 +111,7 @@ internal class EventDispatcher(
 
     companion object {
         private val log = Logger<EventDispatcher>()
-        private val CONTENT_TYPE = MediaType.get("application/json; charset=utf-8")
+        private val CONTENT_TYPE = "application/json; charset=utf-8".toMediaType()
         private const val EVENT_DISPATCH_PATH = "/api/v2/events"
     }
 }

--- a/hackle-android-sdk/src/main/java/io/hackle/android/internal/http/Http.kt
+++ b/hackle-android-sdk/src/main/java/io/hackle/android/internal/http/Http.kt
@@ -1,15 +1,15 @@
 package io.hackle.android.internal.http
 
 import io.hackle.android.internal.utils.json.parseJson
-import okhttp3.MediaType
+import okhttp3.MediaType.Companion.toMediaType
 import okhttp3.Response
 import okhttp3.ResponseBody
 import java.net.HttpURLConnection.HTTP_NOT_MODIFIED
 
 internal val Response.isNotModified: Boolean
     get() {
-        val networkResponse = networkResponse() ?: return false
-        return networkResponse.code() == HTTP_NOT_MODIFIED
+        val networkResponse = networkResponse ?: return false
+        return networkResponse.code == HTTP_NOT_MODIFIED
     }
 
 internal inline fun <reified T> ResponseBody.parse(): T = string().parseJson()
@@ -17,4 +17,4 @@ internal inline fun <reified T> ResponseBody.parse(): T = string().parseJson()
 internal const val HEADER_LAST_MODIFIED = "Last-Modified"
 internal const val HEADER_IF_MODIFIED_SINCE = "If-Modified-Since"
 
-internal val CONTENT_TYPE_APPLICATION_JSON = MediaType.get("application/json; charset=utf-8")
+internal val CONTENT_TYPE_APPLICATION_JSON = "application/json; charset=utf-8".toMediaType()

--- a/hackle-android-sdk/src/main/java/io/hackle/android/internal/invocator/web/HackleJavascriptInterface.kt
+++ b/hackle-android-sdk/src/main/java/io/hackle/android/internal/invocator/web/HackleJavascriptInterface.kt
@@ -1,9 +1,7 @@
 package io.hackle.android.internal.invocator.web
 
-import android.os.Build
 import android.webkit.JavascriptInterface
 import android.webkit.WebView
-import androidx.annotation.RequiresApi
 import io.hackle.android.HackleApp
 import io.hackle.android.internal.utils.json.toJson
 import io.hackle.sdk.common.HackleWebViewConfig
@@ -37,7 +35,6 @@ internal open class HackleJavascriptInterface(
         return app.invocator.invoke(string)
     }
 
-    @RequiresApi(Build.VERSION_CODES.JELLY_BEAN_MR1)
     fun addTo(webView: WebView) {
         webView.addJavascriptInterface(this, NAME)
     }

--- a/hackle-android-sdk/src/main/java/io/hackle/android/internal/monitoring/metric/ApiCallMetrics.kt
+++ b/hackle-android-sdk/src/main/java/io/hackle/android/internal/monitoring/metric/ApiCallMetrics.kt
@@ -39,7 +39,7 @@ internal object ApiCallMetrics {
     }
 
     private fun status(response: Response?): String {
-        return response?.code()?.toString() ?: NONE_TAG
+        return response?.code?.toString() ?: NONE_TAG
     }
 
     private fun exception(e: Throwable?): String {

--- a/hackle-android-sdk/src/main/java/io/hackle/android/internal/monitoring/metric/MonitoringMetricRegistry.kt
+++ b/hackle-android-sdk/src/main/java/io/hackle/android/internal/monitoring/metric/MonitoringMetricRegistry.kt
@@ -11,11 +11,11 @@ import io.hackle.sdk.core.internal.metrics.flush.FlushCounter
 import io.hackle.sdk.core.internal.metrics.flush.FlushMetric
 import io.hackle.sdk.core.internal.metrics.flush.FlushTimer
 import io.hackle.sdk.core.internal.time.Clock
-import okhttp3.HttpUrl
-import okhttp3.MediaType
+import okhttp3.HttpUrl.Companion.toHttpUrl
+import okhttp3.MediaType.Companion.toMediaType
 import okhttp3.OkHttpClient
 import okhttp3.Request
-import okhttp3.RequestBody
+import okhttp3.RequestBody.Companion.toRequestBody
 import java.util.concurrent.Executor
 
 internal class MonitoringMetricRegistry(
@@ -26,7 +26,7 @@ internal class MonitoringMetricRegistry(
     clock: Clock = Clock.SYSTEM,
 ) : MetricRegistry(clock), ApplicationLifecycleListener {
 
-    private val monitoringEndpoint = HttpUrl.get("$monitoringBaseUrl/metrics")
+    private val monitoringEndpoint = "$monitoringBaseUrl/metrics".toHttpUrl()
 
     override fun createCounter(id: Metric.Id): Counter {
         return FlushCounter(id)
@@ -72,7 +72,7 @@ internal class MonitoringMetricRegistry(
 
         val batch = MetricDto.Batch(metrics.map { metric(it) })
 
-        val requestBody = RequestBody.create(CONTENT_TYPE, batch.toJson())
+        val requestBody = batch.toJson().toRequestBody(CONTENT_TYPE)
         val request = Request.Builder()
             .url(monitoringEndpoint)
             .post(requestBody)
@@ -80,7 +80,7 @@ internal class MonitoringMetricRegistry(
 
         httpClient.newCall(request).execute().use { response ->
             if (!response.isSuccessful) {
-                log.warn { "Failed to flushing metrics [${response.code()}]" }
+                log.warn { "Failed to flushing metrics [${response.code}]" }
             }
         }
     }
@@ -100,7 +100,7 @@ internal class MonitoringMetricRegistry(
 
     companion object {
         private val log = Logger<MonitoringMetricRegistry>()
-        private val CONTENT_TYPE = MediaType.get("application/json; charset=utf-8")
+        private val CONTENT_TYPE = "application/json; charset=utf-8".toMediaType()
     }
 }
 

--- a/hackle-android-sdk/src/main/java/io/hackle/android/internal/platform/device/DeviceHelper.kt
+++ b/hackle-android-sdk/src/main/java/io/hackle/android/internal/platform/device/DeviceHelper.kt
@@ -8,7 +8,6 @@ import android.hardware.display.DisplayManager
 import android.os.Build
 import android.util.DisplayMetrics
 import android.view.Display
-import android.view.WindowManager
 import java.util.Locale
 
 internal object DeviceHelper {
@@ -44,18 +43,11 @@ internal object DeviceHelper {
         }
     }
 
-    @Suppress("DEPRECATION")
     fun getDisplayMetrics(context: Context): DisplayMetrics {
         val metrics = DisplayMetrics()
-        if (Build.VERSION.SDK_INT >= Build.VERSION_CODES.JELLY_BEAN_MR1) {
-            val displayManager = context.getSystemService(Context.DISPLAY_SERVICE) as DisplayManager
-            val display = displayManager.getDisplay(Display.DEFAULT_DISPLAY)
-            display.getRealMetrics(metrics)
-        } else {
-            val windowManager = context.getSystemService(Context.WINDOW_SERVICE) as WindowManager
-            val display = windowManager.defaultDisplay
-            display.getMetrics(metrics)
-        }
+        val displayManager = context.getSystemService(Context.DISPLAY_SERVICE) as DisplayManager
+        val display = displayManager.getDisplay(Display.DEFAULT_DISPLAY)
+        display.getRealMetrics(metrics)
         return metrics
     }
 }

--- a/hackle-android-sdk/src/main/java/io/hackle/android/internal/user/UserCohortFetcher.kt
+++ b/hackle-android-sdk/src/main/java/io/hackle/android/internal/user/UserCohortFetcher.kt
@@ -7,7 +7,7 @@ import io.hackle.android.internal.http.parse
 import io.hackle.android.internal.monitoring.metric.ApiCallMetrics
 import io.hackle.android.internal.utils.json.toJson
 import io.hackle.sdk.common.User
-import okhttp3.HttpUrl
+import okhttp3.HttpUrl.Companion.toHttpUrl
 import okhttp3.OkHttpClient
 import okhttp3.Request
 import okhttp3.Response
@@ -17,7 +17,7 @@ internal class UserCohortFetcher(
     sdkUri: String,
     private val httpClient: OkHttpClient,
 ) {
-    private val url = HttpUrl.get(url(sdkUri))
+    private val url = url(sdkUri).toHttpUrl()
 
     fun fetch(user: User): UserCohorts {
         val request = createRequest(user)
@@ -41,8 +41,8 @@ internal class UserCohortFetcher(
     }
 
     private fun handleResponse(response: Response): UserCohorts {
-        check(response.isSuccessful) { "Http status code: ${response.code()}" }
-        val responseBody = checkNotNull(response.body()) { "Response body is null" }
+        check(response.isSuccessful) { "Http status code: ${response.code}" }
+        val responseBody = checkNotNull(response.body) { "Response body is null" }
         val dto = responseBody.parse<UserCohortsResponseDto>()
         return UserCohorts.Companion.from(dto)
     }

--- a/hackle-android-sdk/src/main/java/io/hackle/android/internal/user/UserTargetEventFetcher.kt
+++ b/hackle-android-sdk/src/main/java/io/hackle/android/internal/user/UserTargetEventFetcher.kt
@@ -3,7 +3,7 @@ package io.hackle.android.internal.user
 import io.hackle.android.internal.http.parse
 import io.hackle.android.internal.monitoring.metric.ApiCallMetrics
 import io.hackle.sdk.common.User
-import okhttp3.HttpUrl
+import okhttp3.HttpUrl.Companion.toHttpUrl
 import okhttp3.OkHttpClient
 import okhttp3.Request
 import okhttp3.Response
@@ -17,7 +17,7 @@ internal class UserTargetEventFetcher(
     sdkUri: String,
     private val httpClient: OkHttpClient,
 ) {
-    private val url = HttpUrl.get(url(sdkUri))
+    private val url = url(sdkUri).toHttpUrl()
 
     /**
      * 사용자의 타겟팅 정보를 가져온다.
@@ -45,8 +45,8 @@ internal class UserTargetEventFetcher(
     }
 
     private fun handleResponse(response: Response): UserTargetEvents {
-        check(response.isSuccessful) { "Http status code: ${response.code()}" }
-        val responseBody = checkNotNull(response.body()) { "Response body is null" }
+        check(response.isSuccessful) { "Http status code: ${response.code}" }
+        val responseBody = checkNotNull(response.body) { "Response body is null" }
         val dto = responseBody.parse<UserTargetResponseDto>()
         return UserTargetEvents.Companion.from(dto)
     }

--- a/hackle-android-sdk/src/main/java/io/hackle/android/internal/workspace/HttpWorkspaceFetcher.kt
+++ b/hackle-android-sdk/src/main/java/io/hackle/android/internal/workspace/HttpWorkspaceFetcher.kt
@@ -7,7 +7,7 @@ import io.hackle.android.internal.http.parse
 import io.hackle.android.internal.model.Sdk
 import io.hackle.android.internal.monitoring.metric.ApiCallMetrics
 import io.hackle.sdk.core.internal.log.Logger
-import okhttp3.HttpUrl
+import okhttp3.HttpUrl.Companion.toHttpUrl
 import okhttp3.OkHttpClient
 import okhttp3.Request
 import okhttp3.Response
@@ -17,7 +17,7 @@ internal class HttpWorkspaceFetcher(
     sdkUri: String,
     private val httpClient: OkHttpClient,
 ) {
-    private val url = HttpUrl.get(url(sdk, sdkUri))
+    private val url = url(sdk, sdkUri).toHttpUrl()
 
     fun fetchIfModified(lastModified: String? = null): WorkspaceConfig? {
         val request = createRequest(lastModified)
@@ -43,9 +43,9 @@ internal class HttpWorkspaceFetcher(
             log.debug { "Workspace is not modified." }
             return null
         }
-        check(response.isSuccessful) { "Http status code: ${response.code()}" }
+        check(response.isSuccessful) { "Http status code: ${response.code}" }
         val lastModified = response.header(HEADER_LAST_MODIFIED)
-        val responseBody = checkNotNull(response.body()) { "Response body is null" }
+        val responseBody = checkNotNull(response.body) { "Response body is null" }
         val dto = responseBody.parse<WorkspaceConfigDto>()
 
         log.debug { "Workspace fetched." }

--- a/hackle-android-sdk/src/main/java/io/hackle/android/ui/core/WebViewUserScript.kt
+++ b/hackle-android-sdk/src/main/java/io/hackle/android/ui/core/WebViewUserScript.kt
@@ -1,6 +1,5 @@
 package io.hackle.android.ui.core
 
-import android.os.Build
 import android.webkit.WebView
 
 internal interface WebViewUserScript {
@@ -9,9 +8,5 @@ internal interface WebViewUserScript {
 
 internal fun WebView.evaluate(script: WebViewUserScript) {
     val source = script.source
-    if (Build.VERSION.SDK_INT >= Build.VERSION_CODES.KITKAT) {
-        evaluateJavascript(source, null)
-    } else {
-        loadUrl("javascript:$source")
-    }
+    evaluateJavascript(source, null)
 }

--- a/hackle-android-sdk/src/main/java/io/hackle/android/ui/inappmessage/view/InAppMessageViewController.kt
+++ b/hackle-android-sdk/src/main/java/io/hackle/android/ui/inappmessage/view/InAppMessageViewController.kt
@@ -2,7 +2,6 @@ package io.hackle.android.ui.inappmessage.view
 
 import android.app.Activity
 import android.content.pm.ActivityInfo
-import android.os.Build
 import android.view.ViewGroup
 import androidx.core.view.ViewCompat
 import io.hackle.android.internal.task.TaskExecutors.runOnUiThread
@@ -139,9 +138,7 @@ internal class InAppMessageViewController(
     private fun lockScreenOrientation(activity: Activity) {
         if (originalOrientation == null) {
             originalOrientation = activity.requestedOrientation
-            if (Build.VERSION.SDK_INT >= Build.VERSION_CODES.JELLY_BEAN_MR2) {
-                activity.setActivityRequestedOrientation(ActivityInfo.SCREEN_ORIENTATION_LOCKED)
-            }
+            activity.setActivityRequestedOrientation(ActivityInfo.SCREEN_ORIENTATION_LOCKED)
         }
     }
 

--- a/hackle-android-sdk/src/main/java/io/hackle/android/ui/inappmessage/view/InAppMessageViewFactory.kt
+++ b/hackle-android-sdk/src/main/java/io/hackle/android/ui/inappmessage/view/InAppMessageViewFactory.kt
@@ -1,7 +1,6 @@
 package io.hackle.android.ui.inappmessage.view
 
 import android.app.Activity
-import android.os.Build
 import androidx.webkit.WebViewAssetLoader
 import io.hackle.android.Hackle
 import io.hackle.android.app
@@ -43,11 +42,7 @@ internal class InAppMessageViewFactory(
 
 
     private fun createHtmlView(activity: Activity): InAppMessageHtmlView {
-        if (Build.VERSION.SDK_INT >= Build.VERSION_CODES.JELLY_BEAN_MR1) {
-            val bridgeScript = InAppMessageHtmlBridgeUserScript.create(Hackle.app.config)
-            return InAppMessageHtmlView.create(activity, bridgeScript, assetLoader, htmlContentResolverFactory)
-        }
-
-        throw IllegalStateException("InAppMessageHtmlView required API 17+ (current: ${Build.VERSION.SDK_INT})")
+        val bridgeScript = InAppMessageHtmlBridgeUserScript.create(Hackle.app.config)
+        return InAppMessageHtmlView.create(activity, bridgeScript, assetLoader, htmlContentResolverFactory)
     }
 }

--- a/hackle-android-sdk/src/main/java/io/hackle/android/ui/inappmessage/view/InAppMessageWebViewClient.kt
+++ b/hackle-android-sdk/src/main/java/io/hackle/android/ui/inappmessage/view/InAppMessageWebViewClient.kt
@@ -17,7 +17,6 @@ internal class InAppMessageWebViewClient(
         listener.onPageFinished(view, url)
     }
 
-    @RequiresApi(Build.VERSION_CODES.LOLLIPOP)
     override fun shouldInterceptRequest(view: WebView, request: WebResourceRequest): WebResourceResponse? {
         return assetLoader.shouldInterceptRequest(request.url)
     }
@@ -27,7 +26,6 @@ internal class InAppMessageWebViewClient(
         return assetLoader.shouldInterceptRequest(url.toUri())
     }
 
-    @RequiresApi(Build.VERSION_CODES.LOLLIPOP)
     override fun shouldOverrideUrlLoading(view: WebView, request: WebResourceRequest): Boolean {
         return listener.onUrlLoading(request.url.toString())
     }

--- a/hackle-android-sdk/src/main/java/io/hackle/android/ui/inappmessage/view/html/InAppMessageHtmlContentResolver.kt
+++ b/hackle-android-sdk/src/main/java/io/hackle/android/ui/inappmessage/view/html/InAppMessageHtmlContentResolver.kt
@@ -54,8 +54,8 @@ internal class PathInAppMessageHtmlContentResolver(
     }
 
     private fun handleResponse(response: Response): String {
-        check(response.isSuccessful) { "Http status code: ${response.code()}" }
-        val responseBody = checkNotNull(response.body()) { "Response body is null" }
+        check(response.isSuccessful) { "Http status code: ${response.code}" }
+        val responseBody = checkNotNull(response.body) { "Response body is null" }
         return responseBody.string()
     }
 }

--- a/hackle-android-sdk/src/main/java/io/hackle/android/ui/inappmessage/view/html/InAppMessageHtmlView.kt
+++ b/hackle-android-sdk/src/main/java/io/hackle/android/ui/inappmessage/view/html/InAppMessageHtmlView.kt
@@ -7,7 +7,6 @@ import android.graphics.Color
 import android.os.Build
 import android.util.AttributeSet
 import android.webkit.WebView
-import androidx.annotation.RequiresApi
 import androidx.webkit.WebViewAssetLoader
 import io.hackle.android.Hackle
 import io.hackle.android.R
@@ -25,11 +24,7 @@ import io.hackle.sdk.core.model.InAppMessage
 
 /**
  * In-app message view that renders HTML content via WebView.
- *
- * Requires API 17+ because [android.webkit.WebView.addJavascriptInterface] is only safe
- * from JELLY_BEAN_MR1 onwards. Callers must gate on the API level before creating this view.
  */
-@RequiresApi(Build.VERSION_CODES.JELLY_BEAN_MR1)
 internal class InAppMessageHtmlView @JvmOverloads constructor(
     context: Context,
     attrs: AttributeSet? = null,

--- a/hackle-android-sdk/src/main/java/io/hackle/android/ui/notification/NotificationBroadcastReceiver.kt
+++ b/hackle-android-sdk/src/main/java/io/hackle/android/ui/notification/NotificationBroadcastReceiver.kt
@@ -1,10 +1,13 @@
 package io.hackle.android.ui.notification
 
+import android.Manifest
 import android.app.ActivityManager
 import android.app.KeyguardManager
 import android.content.BroadcastReceiver
 import android.content.Context
 import android.content.Intent
+import android.content.pm.PackageManager
+import androidx.core.app.ActivityCompat
 import androidx.core.app.NotificationManagerCompat
 import io.hackle.android.internal.task.TaskExecutors.runOnBackground
 import io.hackle.android.ui.notification.Constants.DEFAULT_NOTIFICATION_CHANNEL_ID
@@ -51,6 +54,11 @@ internal class NotificationBroadcastReceiver : BroadcastReceiver() {
             }
         }
 
+        if (!hasPostNotificationPermission(context)) {
+            log.debug { "POST_NOTIFICATIONS permission has not been granted. Not posting notification." }
+            return false
+        }
+
         try {
             val notification = NotificationFactory.createNotification(context, notificationExtras, notificationData)
             val notificationManager = NotificationManagerCompat.from(context)
@@ -85,5 +93,11 @@ internal class NotificationBroadcastReceiver : BroadcastReceiver() {
 
         private const val TAG = "hackle_notification"
         private val log = Logger<NotificationBroadcastReceiver>()
+
+        internal fun hasPostNotificationPermission(context: Context): Boolean {
+            return ActivityCompat.checkSelfPermission(
+                context, Manifest.permission.POST_NOTIFICATIONS
+            ) == PackageManager.PERMISSION_GRANTED
+        }
     }
 }

--- a/hackle-android-sdk/src/test/java/io/hackle/android/HackleAppTest.kt
+++ b/hackle-android-sdk/src/test/java/io/hackle/android/HackleAppTest.kt
@@ -10,7 +10,6 @@ import io.hackle.android.internal.application.install.ApplicationInstallStateMan
 import io.hackle.android.internal.application.lifecycle.ApplicationLifecycleManager
 import io.hackle.android.internal.event.DefaultEventProcessor
 import io.hackle.android.internal.invocator.web.HackleJavascriptInterface
-import io.hackle.android.internal.model.AndroidBuild
 import io.hackle.android.internal.model.Sdk
 import io.hackle.android.internal.notification.NotificationManager
 import io.hackle.android.internal.optout.OptOutManager
@@ -24,7 +23,6 @@ import io.hackle.android.internal.user.UserManager
 import io.hackle.android.internal.utils.concurrent.Throttler
 import io.hackle.android.internal.workspace.WorkspaceManager
 import io.hackle.android.mock.MockDevice
-import io.hackle.android.support.assertThrows
 import io.hackle.android.ui.explorer.HackleUserExplorer
 import io.hackle.android.ui.inappmessage.InAppMessageUi
 import io.hackle.android.ui.inappmessage.view.InAppMessageView
@@ -743,31 +741,12 @@ class HackleAppTest {
 
     @Test
     fun `setWebViewBridge success`() {
-        mockkObject(AndroidBuild)
-        every { AndroidBuild.sdkVersion() } returns 17
-
         val webView = mockk<WebView>(relaxed = true)
         sut.setWebViewBridge(webView)
 
         verify(exactly = 1) {
             webView.addJavascriptInterface(any<HackleJavascriptInterface>(), "_hackleApp")
         }
-
-        unmockkObject(AndroidBuild)
-    }
-
-    @Test
-    fun `setWebViewBridge fail`() {
-        mockkObject(AndroidBuild)
-        every { AndroidBuild.sdkVersion() } returns 16
-
-        val webView = mockk<WebView>(relaxed = true)
-
-        assertThrows<IllegalStateException> {
-            sut.setWebViewBridge(webView)
-        }
-
-        unmockkObject(AndroidBuild)
     }
 
     @Test

--- a/hackle-android-sdk/src/test/java/io/hackle/android/internal/user/UserTargetEventFetcherTest.kt
+++ b/hackle-android-sdk/src/test/java/io/hackle/android/internal/user/UserTargetEventFetcherTest.kt
@@ -14,6 +14,7 @@ import okhttp3.Call
 import okhttp3.OkHttpClient
 import okhttp3.Response
 import okhttp3.ResponseBody
+import okhttp3.ResponseBody.Companion.toResponseBody
 import org.junit.Before
 import org.junit.Test
 import strikt.api.expectThat
@@ -147,7 +148,7 @@ internal fun MockKStubScope<Call, Call>.response(statusCode: Int, body: String? 
         .protocol(mockk())
         .code(statusCode)
         .message(statusCode.toString())
-        .body(body?.let { ResponseBody.create(null, it) })
+        .body(body?.toResponseBody(null))
         .build()
     val call = mockk<Call> {
         every { execute() } returns response

--- a/hackle-android-sdk/src/test/java/io/hackle/android/internal/workspace/HttpWorkspaceFetcherTest.kt
+++ b/hackle-android-sdk/src/test/java/io/hackle/android/internal/workspace/HttpWorkspaceFetcherTest.kt
@@ -6,10 +6,11 @@ import io.mockk.every
 import io.mockk.mockk
 import io.mockk.verify
 import okhttp3.Call
-import okhttp3.Headers
+import okhttp3.Headers.Companion.toHeaders
 import okhttp3.OkHttpClient
 import okhttp3.Response
 import okhttp3.ResponseBody
+import okhttp3.ResponseBody.Companion.toResponseBody
 import org.junit.Before
 import org.junit.Test
 import strikt.api.expectThat
@@ -131,7 +132,7 @@ class HttpWorkspaceFetcherTest {
             .request(mockk())
             .protocol(mockk())
             .code(statusCode)
-            .headers(Headers.of(headers))
+            .headers(headers.toHeaders())
             .networkResponse(
                 Response.Builder()
                     .request(mockk())
@@ -140,7 +141,7 @@ class HttpWorkspaceFetcherTest {
                     .message(statusCode.toString())
                     .build()
             )
-            .body(body?.let { ResponseBody.create(null, it) })
+            .body(body?.toResponseBody(null))
             .message(statusCode.toString())
             .build()
         return mockk {

--- a/hackle-android-sdk/src/test/java/io/hackle/android/ui/notification/NotificationBroadcastReceiverTest.kt
+++ b/hackle-android-sdk/src/test/java/io/hackle/android/ui/notification/NotificationBroadcastReceiverTest.kt
@@ -1,0 +1,216 @@
+package io.hackle.android.ui.notification
+
+import android.app.ActivityManager
+import android.app.KeyguardManager
+import android.app.Notification
+import android.content.Context
+import android.content.Intent
+import androidx.core.app.NotificationManagerCompat
+import io.hackle.android.internal.task.TaskExecutors
+import io.mockk.every
+import io.mockk.mockk
+import io.mockk.mockkObject
+import io.mockk.mockkStatic
+import io.mockk.unmockkAll
+import io.mockk.verify
+import org.junit.After
+import org.junit.Before
+import org.junit.Test
+
+class NotificationBroadcastReceiverTest {
+
+    private lateinit var sut: NotificationBroadcastReceiver
+    private lateinit var context: Context
+    private lateinit var notificationData: NotificationData
+    private lateinit var notificationManager: NotificationManagerCompat
+
+    @Before
+    fun setUp() {
+        sut = NotificationBroadcastReceiver()
+        context = mockk(relaxed = true)
+        notificationData = mockk(relaxed = true) {
+            every { showForeground } returns true
+            every { notificationId } returns 42
+        }
+
+        // Run the runOnBackground async block synchronously inside onReceive.
+        mockkObject(TaskExecutors)
+        every { TaskExecutors.runOnBackground(any()) } answers {
+            firstArg<() -> Unit>().invoke()
+        }
+
+        // Default stubs: treat the intent as a hackle intent and let NotificationData.from parse successfully.
+        mockkObject(NotificationHandler.Companion)
+        every { NotificationHandler.isHackleIntent(any()) } returns true
+        mockkObject(NotificationData.Companion)
+        every { NotificationData.from(any()) } returns notificationData
+
+        // The permission check helper is exposed as a testable seam.
+        mockkObject(NotificationBroadcastReceiver.Companion)
+        every { NotificationBroadcastReceiver.hasPostNotificationPermission(any()) } returns true
+
+        // The number of NotificationFactory invocations indicates whether displayNotification reached the post branch.
+        mockkObject(NotificationFactory)
+        every { NotificationFactory.createNotification(any(), any(), any()) } returns mockk<Notification>(relaxed = true)
+
+        // Stub NotificationManagerCompat.from so that notify(...) calls can be verified.
+        notificationManager = mockk(relaxed = true)
+        mockkStatic(NotificationManagerCompat::class)
+        every { NotificationManagerCompat.from(any()) } returns notificationManager
+
+        // Default the foreground check to false (app is in background).
+        val keyguardManager = mockk<KeyguardManager>(relaxed = true) {
+            every { isKeyguardLocked } returns false
+        }
+        val activityManager = mockk<ActivityManager>(relaxed = true) {
+            every { runningAppProcesses } returns emptyList()
+        }
+        every { context.getSystemService(Context.KEYGUARD_SERVICE) } returns keyguardManager
+        every { context.getSystemService(Context.ACTIVITY_SERVICE) } returns activityManager
+        every { context.packageName } returns "io.hackle.test"
+    }
+
+    @After
+    fun tearDown() {
+        unmockkAll()
+    }
+
+    @Test
+    fun `intent null - createNotification not called`() {
+        sut.onReceive(context, null)
+
+        verify(exactly = 0) { NotificationFactory.createNotification(any(), any(), any()) }
+        verify(exactly = 0) { notificationManager.notify(any<String>(), any(), any<Notification>()) }
+    }
+
+    @Test
+    fun `non-hackle intent - createNotification not called`() {
+        every { NotificationHandler.isHackleIntent(any()) } returns false
+        val intent = mockk<Intent>(relaxed = true)
+
+        sut.onReceive(context, intent)
+
+        verify(exactly = 0) { NotificationFactory.createNotification(any(), any(), any()) }
+        verify(exactly = 0) { notificationManager.notify(any<String>(), any(), any<Notification>()) }
+    }
+
+    @Test
+    fun `intent extras null - createNotification not called`() {
+        val intent = mockk<Intent>(relaxed = true) {
+            every { extras } returns null
+        }
+
+        sut.onReceive(context, intent)
+
+        verify(exactly = 0) { NotificationFactory.createNotification(any(), any(), any()) }
+        verify(exactly = 0) { notificationManager.notify(any<String>(), any(), any<Notification>()) }
+    }
+
+    @Test
+    fun `notification data parse error - createNotification not called`() {
+        every { NotificationData.from(any()) } returns null
+        val intent = mockk<Intent>(relaxed = true)
+
+        sut.onReceive(context, intent)
+
+        verify(exactly = 0) { NotificationFactory.createNotification(any(), any(), any()) }
+        verify(exactly = 0) { notificationManager.notify(any<String>(), any(), any<Notification>()) }
+    }
+
+    @Test
+    fun `app in foreground and showForeground false - createNotification not called`() {
+        every { notificationData.showForeground } returns false
+        val foregroundProcess = ActivityManager.RunningAppProcessInfo().apply {
+            importance = ActivityManager.RunningAppProcessInfo.IMPORTANCE_FOREGROUND
+            processName = "io.hackle.test"
+        }
+        val activityManager = mockk<ActivityManager>(relaxed = true) {
+            every { runningAppProcesses } returns listOf(foregroundProcess)
+        }
+        every { context.getSystemService(Context.ACTIVITY_SERVICE) } returns activityManager
+        val intent = mockk<Intent>(relaxed = true)
+
+        sut.onReceive(context, intent)
+
+        verify(exactly = 0) { NotificationFactory.createNotification(any(), any(), any()) }
+        verify(exactly = 0) { notificationManager.notify(any<String>(), any(), any<Notification>()) }
+    }
+
+    @Test
+    fun `POST_NOTIFICATIONS permission denied - createNotification not called`() {
+        every { NotificationBroadcastReceiver.hasPostNotificationPermission(any()) } returns false
+        val intent = mockk<Intent>(relaxed = true)
+
+        sut.onReceive(context, intent)
+
+        verify(exactly = 0) { NotificationFactory.createNotification(any(), any(), any()) }
+        verify(exactly = 0) { notificationManager.notify(any<String>(), any(), any<Notification>()) }
+    }
+
+    @Test
+    fun `permission granted and intent valid - createNotification called`() {
+        val intent = mockk<Intent>(relaxed = true)
+
+        sut.onReceive(context, intent)
+
+        verify(exactly = 1) { NotificationFactory.createNotification(any(), any(), notificationData) }
+        verify(exactly = 1) { notificationManager.notify("hackle_notification", 42, any<Notification>()) }
+    }
+
+    // When showForeground=true, the notification must be posted even if the app is in the foreground.
+    @Test
+    fun `showForeground true and app in foreground - notification posted`() {
+        val foregroundProcess = ActivityManager.RunningAppProcessInfo().apply {
+            importance = ActivityManager.RunningAppProcessInfo.IMPORTANCE_FOREGROUND
+            processName = "io.hackle.test"
+        }
+        val activityManager = mockk<ActivityManager>(relaxed = true) {
+            every { runningAppProcesses } returns listOf(foregroundProcess)
+        }
+        every { context.getSystemService(Context.ACTIVITY_SERVICE) } returns activityManager
+        val intent = mockk<Intent>(relaxed = true)
+
+        sut.onReceive(context, intent)
+
+        verify(exactly = 1) { NotificationFactory.createNotification(any(), any(), notificationData) }
+        verify(exactly = 1) { notificationManager.notify("hackle_notification", 42, any<Notification>()) }
+    }
+
+    // When the keyguard is locked, isAppInForeground returns false, so the notification is posted
+    // even with showForeground=false.
+    @Test
+    fun `keyguard locked and showForeground false - notification posted`() {
+        every { notificationData.showForeground } returns false
+        val keyguardManager = mockk<KeyguardManager>(relaxed = true) {
+            every { isKeyguardLocked } returns true
+        }
+        val foregroundProcess = ActivityManager.RunningAppProcessInfo().apply {
+            importance = ActivityManager.RunningAppProcessInfo.IMPORTANCE_FOREGROUND
+            processName = "io.hackle.test"
+        }
+        val activityManager = mockk<ActivityManager>(relaxed = true) {
+            every { runningAppProcesses } returns listOf(foregroundProcess)
+        }
+        every { context.getSystemService(Context.KEYGUARD_SERVICE) } returns keyguardManager
+        every { context.getSystemService(Context.ACTIVITY_SERVICE) } returns activityManager
+        val intent = mockk<Intent>(relaxed = true)
+
+        sut.onReceive(context, intent)
+
+        verify(exactly = 1) { NotificationFactory.createNotification(any(), any(), notificationData) }
+        verify(exactly = 1) { notificationManager.notify("hackle_notification", 42, any<Notification>()) }
+    }
+
+    // The try/catch in displayNotification swallows the createNotification exception and onReceive returns normally.
+    @Test
+    fun `createNotification throws - notify not called and onReceive does not propagate`() {
+        every { NotificationFactory.createNotification(any(), any(), any()) } throws RuntimeException("boom")
+        val intent = mockk<Intent>(relaxed = true)
+
+        sut.onReceive(context, intent)
+
+        verify(exactly = 1) { NotificationFactory.createNotification(any(), any(), notificationData) }
+        verify(exactly = 0) { notificationManager.notify(any<String>(), any(), any<Notification>()) }
+    }
+
+}


### PR DESCRIPTION
## 개요
Android SDK 최소/타깃 버전을 상향하고, 이에 맞춰 OkHttp을 4.x로 마이그레이션합니다.

## 주요 변경사항

| 항목 | 변경 전 | 변경 후 |
|------|---------|---------|
| `minSdkVersion` | 16 | 21 |
| `targetSdkVersion` | 31 | 34 |
| `compileSdkVersion` | 31 | 34 |
| `androidx.core:core-ktx` | 1.3.2 | 1.13.1 |
| `com.squareup.okhttp3:okhttp` | 3.12.2 | 4.12.0 |

## 작업 내용
- minSdk 상향에 따른 `AndroidBuild` SDK version 분기 및 `setWebViewBridge`의 JELLY_BEAN_MR1 가드 제거
- Android 13+ `POST_NOTIFICATIONS` 권한 처리 반영
- OkHttp 4의 Kotlin property API로 호출부 일괄 전환 (`response.code()` → `response.code`, `MediaType.get(...)` → `String.toMediaType()`, `HttpUrl.get(...)` → `String.toHttpUrl()`, `RequestBody.create(...)` → `ByteArray.toRequestBody(...)` 등)
- `NotificationBroadcastReceiver` 테스트 신규 추가 및 OkHttp 4 마이그레이션에 맞춰 기존 테스트 적응
