### PR TITLE
fix: guard listener throws in ApplicationLifecycleManager

### DIFF
--- a/hackle-android-sdk/src/main/java/io/hackle/android/internal/application/lifecycle/ApplicationLifecycleManager.kt
+++ b/hackle-android-sdk/src/main/java/io/hackle/android/internal/application/lifecycle/ApplicationLifecycleManager.kt
@@ -30,8 +30,24 @@ internal class ApplicationLifecycleManager(
             log.debug { "application($state)" }
             val timestamp = clock.currentMillis()
             when (state) {
-                ApplicationState.FOREGROUND -> listeners.forEach { it.onForeground(timestamp, false) }
-                ApplicationState.BACKGROUND -> listeners.forEach { it.onBackground(timestamp) }
+                ApplicationState.FOREGROUND -> {
+                    for (listener in listeners) {
+                        try {
+                            listener.onForeground(timestamp, false)
+                        } catch (e: Throwable) {
+                            log.error { "Failed to handle onForeground [${listener.javaClass.simpleName}]: $e" }
+                        }
+                    }
+                }
+                ApplicationState.BACKGROUND -> {
+                    for (listener in listeners) {
+                        try {
+                            listener.onBackground(timestamp)
+                        } catch (e: Throwable) {
+                            log.error { "Failed to handle onBackground [${listener.javaClass.simpleName}]: $e" }
+                        }
+                    }
+                }
             }
         }
     }
@@ -75,7 +91,13 @@ internal class ApplicationLifecycleManager(
             log.debug { "application(onForeground)" }
             val isFromBackground = _currentState == ApplicationState.BACKGROUND
             execute {
-                listeners.forEach { it.onForeground(timestamp, isFromBackground) }
+                for (listener in listeners) {
+                    try {
+                        listener.onForeground(timestamp, isFromBackground)
+                    } catch (e: Throwable) {
+                        log.error { "Failed to handle onForeground [${listener.javaClass.simpleName}]: $e" }
+                    }
+                }
                 _currentState = ApplicationState.FOREGROUND
             }
         }
@@ -87,7 +109,13 @@ internal class ApplicationLifecycleManager(
         if (enableActivities.isEmpty()) {
             log.debug { "application(onBackground)" }
             execute {
-                listeners.forEach { it.onBackground(timestamp) }
+                for (listener in listeners) {
+                    try {
+                        listener.onBackground(timestamp)
+                    } catch (e: Throwable) {
+                        log.error { "Failed to handle onBackground [${listener.javaClass.simpleName}]: $e" }
+                    }
+                }
                 _currentState = ApplicationState.BACKGROUND
             }
         }

--- a/hackle-android-sdk/src/test/java/io/hackle/android/internal/application/ApplicationLifecycleManagerTest.kt
+++ b/hackle-android-sdk/src/test/java/io/hackle/android/internal/application/ApplicationLifecycleManagerTest.kt
@@ -275,4 +275,64 @@ class ApplicationLifecycleManagerTest {
         verify { syncExecutor.execute(any()) }
         verify { mockListener.onForeground(1234567890L, false) }
     }
+
+    @Test
+    fun `onActivityStarted should continue invoking remaining listeners when one throws`() {
+        // given
+        val freshManager = ApplicationLifecycleManager(mockClock)
+        val listener1 = mockk<ApplicationLifecycleListener>()
+        val listener2 = mockk<ApplicationLifecycleListener>(relaxed = true)
+        every { listener1.onForeground(any(), any()) } throws RuntimeException("boom")
+
+        freshManager.addListener(listener1)
+        freshManager.addListener(listener2)
+
+        // when - 시스템 lifecycle callback 으로 throw 가 전파되지 않아야 함
+        freshManager.onActivityStarted(mockActivity1)
+
+        // then
+        verify { listener1.onForeground(1234567890L, false) }
+        verify { listener2.onForeground(1234567890L, false) }
+    }
+
+    @Test
+    fun `onActivityStopped should continue invoking remaining listeners when one throws`() {
+        // given - 먼저 FG 진입 (mockListener 가 setUp 에 등록되어 있지 않은 fresh manager 사용)
+        val freshManager = ApplicationLifecycleManager(mockClock)
+        val listener1 = mockk<ApplicationLifecycleListener>(relaxed = true)
+        val listener2 = mockk<ApplicationLifecycleListener>(relaxed = true)
+        freshManager.addListener(listener1)
+        freshManager.addListener(listener2)
+        freshManager.onActivityStarted(mockActivity1) // FG 전환
+        // BG 콜백에서만 throw 하도록 설정
+        every { listener1.onBackground(any()) } throws RuntimeException("boom")
+
+        // when
+        freshManager.onActivityStopped(mockActivity1)
+
+        // then
+        verify { listener1.onBackground(1234567890L) }
+        verify { listener2.onBackground(1234567890L) }
+    }
+
+    @Test
+    fun `publishStateIfNeeded should continue invoking remaining listeners when one throws`() {
+        // given - FG 상태로 전환 (이 시점에는 listener1 도 정상 호출되도록 relaxed)
+        val freshManager = ApplicationLifecycleManager(mockClock)
+        val listener1 = mockk<ApplicationLifecycleListener>(relaxed = true)
+        val listener2 = mockk<ApplicationLifecycleListener>(relaxed = true)
+        freshManager.addListener(listener1)
+        freshManager.addListener(listener2)
+        freshManager.onActivityStarted(mockActivity1)
+
+        // FG 진입 후에 throw stub 등록 (publishStateIfNeeded 호출 시에만 throw)
+        every { listener1.onForeground(any(), any()) } throws RuntimeException("boom")
+
+        // when
+        freshManager.publishStateIfNeeded()
+
+        // then - publishStateIfNeeded 의 FG 경로에서 listener1 throw 에도 listener2 호출됨
+        verify { listener1.onForeground(1234567890L, false) }
+        verify { listener2.onForeground(1234567890L, false) }
+    }
 }


### PR DESCRIPTION
## 개요
`ApplicationLifecycleManager`에서 등록된 listener 중 하나가 예외를 던지면 이후 listener들이 호출되지 않고, 예외가 시스템 lifecycle 콜백까지 전파되는 문제를 수정합니다.

각 listener 호출을 `try/catch`로 감싸 예외를 로그로 남기고, 나머지 listener들도 정상적으로 호출되도록 보장합니다.

## 작업 내용
- `publishState`의 FOREGROUND/BACKGROUND 처리에서 listener별 예외 격리
- `onActivityStarted`(FG 진입), `onActivityStopped`(BG 진입) 경로에서 listener별 예외 격리
- 각 경로에 대해 listener throw 시 나머지 listener가 계속 호출되는지 검증하는 테스트 추가

## 참고
- HACKLE-14087