### PR TITLE
feature: add release assemble workflow

### DIFF
--- a/.github/workflows/test.yml
+++ b/.github/workflows/test.yml
@@ -46,3 +46,27 @@ jobs:
           token: ${{ secrets.GITHUB_TOKEN }}
           title: Coverage
           update-comment: true
+
+  android-sdk-assemble-release:
+    runs-on: ubuntu-22.04
+    steps:
+      - uses: actions/checkout@v2
+      - name: Set up JDK 17
+        uses: actions/setup-java@v4
+        with:
+          java-version: '17'
+          distribution: 'temurin'
+
+      - name: Set up Gradle
+        uses: gradle/gradle-build-action@v2
+        with:
+          gradle-version: 8.7
+          cache-read-only: false
+          gradle-home-cache-cleanup: true
+
+      - name: Assemble Release
+        run: ./gradlew :hackle-android-sdk:assembleRelease --quiet --no-daemon --warning-mode=none
+        env:
+          ANDROID_SDK_SUPPRESS_WARNINGS: true
+          ANDROID_SUPPRESS_ALL_WARNINGS: true
+          JAVA_TOOL_OPTIONS: "-Dfile.encoding=UTF-8 -Djava.awt.headless=true"

--- a/hackle-android-sdk/src/main/java/io/hackle/android/internal/application/lifecycle/ApplicationLifecycleManager.kt
+++ b/hackle-android-sdk/src/main/java/io/hackle/android/internal/application/lifecycle/ApplicationLifecycleManager.kt
@@ -30,24 +30,8 @@ internal class ApplicationLifecycleManager(
             log.debug { "application($state)" }
             val timestamp = clock.currentMillis()
             when (state) {
-                ApplicationState.FOREGROUND -> {
-                    for (listener in listeners) {
-                        try {
-                            listener.onForeground(timestamp, false)
-                        } catch (e: Throwable) {
-                            log.error { "Failed to handle onForeground [${listener.javaClass.simpleName}]: $e" }
-                        }
-                    }
-                }
-                ApplicationState.BACKGROUND -> {
-                    for (listener in listeners) {
-                        try {
-                            listener.onBackground(timestamp)
-                        } catch (e: Throwable) {
-                            log.error { "Failed to handle onBackground [${listener.javaClass.simpleName}]: $e" }
-                        }
-                    }
-                }
+                ApplicationState.FOREGROUND -> notifyListeners(state) { it.onForeground(timestamp, false) }
+                ApplicationState.BACKGROUND -> notifyListeners(state) { it.onBackground(timestamp) }
             }
         }
     }
@@ -91,13 +75,7 @@ internal class ApplicationLifecycleManager(
             log.debug { "application(onForeground)" }
             val isFromBackground = _currentState == ApplicationState.BACKGROUND
             execute {
-                for (listener in listeners) {
-                    try {
-                        listener.onForeground(timestamp, isFromBackground)
-                    } catch (e: Throwable) {
-                        log.error { "Failed to handle onForeground [${listener.javaClass.simpleName}]: $e" }
-                    }
-                }
+                notifyListeners(ApplicationState.FOREGROUND) { it.onForeground(timestamp, isFromBackground) }
                 _currentState = ApplicationState.FOREGROUND
             }
         }
@@ -109,14 +87,18 @@ internal class ApplicationLifecycleManager(
         if (enableActivities.isEmpty()) {
             log.debug { "application(onBackground)" }
             execute {
-                for (listener in listeners) {
-                    try {
-                        listener.onBackground(timestamp)
-                    } catch (e: Throwable) {
-                        log.error { "Failed to handle onBackground [${listener.javaClass.simpleName}]: $e" }
-                    }
-                }
+                notifyListeners(ApplicationState.BACKGROUND) { it.onBackground(timestamp) }
                 _currentState = ApplicationState.BACKGROUND
+            }
+        }
+    }
+
+    private inline fun notifyListeners(event: ApplicationState, block: (ApplicationLifecycleListener) -> Unit) {
+        for (listener in listeners) {
+            try {
+                block(listener)
+            } catch (e: Throwable) {
+                log.error(e) { "Failed to handle $event [${listener.javaClass.simpleName}]" }
             }
         }
     }


### PR DESCRIPTION
## 개요
Android SDK release assemble을 CI에서 별도 검증하도록 test workflow에 job을 추가합니다.
Application lifecycle listener 알림 로직을 공통 함수로 정리하고, listener 예외 로그에 원인 예외가 포함되도록 개선합니다.

## 작업 내용
- `test.yml`에 `:hackle-android-sdk:assembleRelease` 검증 job 추가
- application foreground/background listener 알림 로직 중복 제거
- listener 처리 실패 로그에 throwable 전달