### PR TITLE
fix: catch Throwable in notification handler to prevent crashes

### DIFF
--- a/hackle-android-sdk/src/main/java/io/hackle/android/internal/notification/NotificationManager.kt
+++ b/hackle-android-sdk/src/main/java/io/hackle/android/internal/notification/NotificationManager.kt
@@ -47,8 +47,8 @@ internal class NotificationManager(
             }
 
             track(data.toTrackEvent(), userManager.currentUser, timestamp)
-        } catch (e: Exception) {
-            log.error { "Failed to handle notification data: ${data.messageId}" }
+        } catch (e: Throwable) {
+            log.error(e) { "Failed to handle notification data: ${data.messageId}" }
         }
     }
 

--- a/hackle-android-sdk/src/test/java/io/hackle/android/internal/notification/NotificationManagerTest.kt
+++ b/hackle-android-sdk/src/test/java/io/hackle/android/internal/notification/NotificationManagerTest.kt
@@ -105,6 +105,42 @@ class NotificationManagerTest {
     }
 
     @Test
+    fun `does not propagate non-Exception throwable raised while handling notification`() {
+        // given - track raises an Error (Throwable, not Exception)
+        every { core.track(any(), any(), any()) } answers { throw AssertionError("boom") }
+
+        val data = NotificationData(
+            "hackle",
+            "abcd1234",
+            111L,
+            222L,
+            1111L,
+            2222L,
+            3333L,
+            4444L,
+            true,
+            "#FF00FF",
+            "foo",
+            "bar",
+            "https://foo.bar/image",
+            "https://foo.foo",
+            NotificationClickAction.APP_OPEN,
+            "foo://bar",
+            1L,
+            2L,
+            3L,
+            "JOURNEY",
+            true
+        )
+
+        // when - must not propagate to the (main-thread) caller
+        manager.onNotificationDataReceived(data, 1L)
+
+        // then - the throwable came from the handling path and was swallowed
+        verify(exactly = 1) { core.track(any(), any(), any()) }
+    }
+
+    @Test
     fun `save notification data if environment is not same`() {
         val timestamp = System.currentTimeMillis()
         val correctData = NotificationData(


### PR DESCRIPTION
## 개요
알림 데이터 처리 중 `Exception`이 아닌 `Throwable`(`AssertionError` 등)이 발생했을 때 앱이 크래시되는 문제를 수정합니다.
`catch (Exception)` → `catch (Throwable)`로 변경하고, 로그에 예외 객체를 함께 기록하도록 개선하였습니다.

## 작업 내용
- `NotificationManager`: `catch (Exception)` → `catch (Throwable)` 로 변경하여 JVM Error 계열도 삼킴
- `NotificationManager`: `log.error(e)` 로 예외 스택트레이스 포함 로깅
- `NotificationManagerTest`: `Throwable`이 콜러로 전파되지 않음을 검증하는 테스트 추가