### PR TITLE
fix: preserve versionCode when versionName is null

### DIFF
--- a/hackle-android-sdk/src/main/java/io/hackle/android/internal/platform/packageinfo/PackageInfo.kt
+++ b/hackle-android-sdk/src/main/java/io/hackle/android/internal/platform/packageinfo/PackageInfo.kt
@@ -16,8 +16,8 @@ internal interface PackageInfo {
             var versionCode = 0L
             try {
                 val packageInfo = context.packageManager.getPackageInfo(context.packageName, 0)
-                packageName = packageInfo.packageName
-                versionName = packageInfo.versionName
+                packageName = packageInfo.packageName ?: ""
+                versionName = packageInfo.versionName ?: ""
                 @Suppress("DEPRECATION")
                 versionCode = if (Build.VERSION.SDK_INT >= Build.VERSION_CODES.P)
                     packageInfo.longVersionCode else packageInfo.versionCode.toLong()

--- a/hackle-android-sdk/src/test/java/io/hackle/android/internal/platform/packageinfo/PackageInfoCreateTest.kt
+++ b/hackle-android-sdk/src/test/java/io/hackle/android/internal/platform/packageinfo/PackageInfoCreateTest.kt
@@ -1,0 +1,37 @@
+package io.hackle.android.internal.platform.packageinfo
+
+import android.content.Context
+import android.content.pm.PackageManager
+import io.mockk.every
+import io.mockk.mockk
+import org.junit.Test
+import strikt.api.expectThat
+import strikt.assertions.isEqualTo
+
+class PackageInfoCreateTest {
+
+    @Test
+    fun `create populates versionCode even when platform versionName is null`() {
+        // given - some APKs / split installs report a null versionName.
+        // Assigning it to the non-null String used to throw, dropping into
+        // the catch block before versionCode (assigned afterwards) was set.
+        val androidPackageInfo = mockk<android.content.pm.PackageInfo>(relaxed = true)
+        androidPackageInfo.versionName = null
+        @Suppress("DEPRECATION")
+        androidPackageInfo.versionCode = 42
+
+        val packageManager = mockk<PackageManager>()
+        every { packageManager.getPackageInfo(any<String>(), any<Int>()) } returns androidPackageInfo
+
+        val context = mockk<Context>()
+        every { context.packageManager } returns packageManager
+        every { context.packageName } returns "io.hackle.app"
+
+        // when
+        val packageInfo = PackageInfo.create(context)
+
+        // then - versionName falls back to "" and versionCode is no longer skipped
+        expectThat(packageInfo.properties["versionName"]).isEqualTo("")
+        expectThat(packageInfo.properties["versionCode"]).isEqualTo(42L)
+    }
+}


### PR DESCRIPTION
## 개요
Android PackageInfo에서 versionName이 null로 전달될 때 SDK 초기화 중 versionCode가 0으로 유실되는 문제를 수정합니다.
versionName과 packageName을 null-safe하게 처리하여 PackageInfo.create가 정상적으로 PackageVersionInfo를 구성하도록 변경하였습니다.

## 작업 내용
- PackageInfo.create에서 platform PackageInfo의 nullable 문자열 값을 fallback 처리
- versionName이 null이어도 versionCode를 유지하는 회귀 테스트 추가