### PR TITLE
fix: isolate in-app message event handlers

### DIFF
--- a/hackle-android-sdk/src/main/java/io/hackle/android/ui/inappmessage/event/InAppMessageViewEventHandleProcessor.kt
+++ b/hackle-android-sdk/src/main/java/io/hackle/android/ui/inappmessage/event/InAppMessageViewEventHandleProcessor.kt
@@ -1,6 +1,7 @@
 package io.hackle.android.ui.inappmessage.event
 
 import io.hackle.android.ui.inappmessage.view.InAppMessageView
+import io.hackle.sdk.core.internal.log.Logger
 
 internal class InAppMessageViewEventHandleProcessor(
     private val handlerFactory: InAppMessageViewEventHandlerFactory,
@@ -8,8 +9,17 @@ internal class InAppMessageViewEventHandleProcessor(
 
     fun process(view: InAppMessageView, event: InAppMessageViewEvent, types: List<InAppMessageViewEventHandleType>) {
         for (handleType in types) {
-            val handler = handlerFactory.get(handleType)
-            handler.handle(view, event)
+            // 한 핸들러(트래킹/액션/호스트 콜백)의 예외가 다른 핸들러와 UI 클릭 콜백으로 전파되지 않도록 격리한다.
+            try {
+                val handler = handlerFactory.get(handleType)
+                handler.handle(view, event)
+            } catch (e: Throwable) {
+                log.error { "Failed to handle InAppMessage view event [$handleType]: $e" }
+            }
         }
+    }
+
+    companion object {
+        private val log = Logger<InAppMessageViewEventHandleProcessor>()
     }
 }

--- a/hackle-android-sdk/src/main/java/io/hackle/android/ui/inappmessage/event/InAppMessageViewEventHandleProcessor.kt
+++ b/hackle-android-sdk/src/main/java/io/hackle/android/ui/inappmessage/event/InAppMessageViewEventHandleProcessor.kt
@@ -9,7 +9,6 @@ internal class InAppMessageViewEventHandleProcessor(
 
     fun process(view: InAppMessageView, event: InAppMessageViewEvent, types: List<InAppMessageViewEventHandleType>) {
         for (handleType in types) {
-            // 한 핸들러(트래킹/액션/호스트 콜백)의 예외가 다른 핸들러와 UI 클릭 콜백으로 전파되지 않도록 격리한다.
             try {
                 val handler = handlerFactory.get(handleType)
                 handler.handle(view, event)

--- a/hackle-android-sdk/src/test/java/io/hackle/android/ui/inappmessage/event/InAppMessageViewEventHandleProcessorTest.kt
+++ b/hackle-android-sdk/src/test/java/io/hackle/android/ui/inappmessage/event/InAppMessageViewEventHandleProcessorTest.kt
@@ -46,6 +46,25 @@ internal class InAppMessageViewEventHandleProcessorTest {
     }
 
     @Test
+    fun `when a handler throws then remaining handlers still run and exception is not propagated`() {
+        // given
+        val view = mockk<InAppMessageView>()
+        val event = mockk<InAppMessageViewEvent>()
+
+        val throwingHandler = mockk<InAppMessageViewEventHandler>()
+        val otherHandler = mockk<InAppMessageViewEventHandler>(relaxUnitFun = true)
+        every { handlerFactory.get(TRACK) } returns throwingHandler
+        every { handlerFactory.get(ACTION) } returns otherHandler
+        every { throwingHandler.handle(any(), any()) } throws RuntimeException("boom")
+
+        // when - must not propagate to the click/track caller
+        sut.process(view, event, listOf(TRACK, ACTION))
+
+        // then - the failure of one handler must not skip the others
+        verify(exactly = 1) { otherHandler.handle(view, event) }
+    }
+
+    @Test
     fun `when types is empty then do nothing`() {
         // given
         val view = mockk<InAppMessageView>()


### PR DESCRIPTION
## 개요
In-App Message view event 처리 중 특정 handler에서 예외가 발생해도 나머지 handler가 계속 실행되도록 수정합니다.
handler별 예외를 격리하고 실패 내용을 error log로 남겨 click/track 호출부까지 예외가 전파되지 않도록 했습니다.

## 작업 내용
- `InAppMessageViewEventHandleProcessor`에서 handler 실행 단위로 `Throwable`을 catch하도록 변경
- handler 실패 시 처리 중인 `handleType`과 예외 정보를 error log로 기록
- 한 handler가 실패해도 다음 handler가 실행되는지 검증하는 테스트 추가