### PR TITLE
feat: inject in-app message HTML bridge at document start

### DIFF
--- a/hackle-android-sdk/build.gradle
+++ b/hackle-android-sdk/build.gradle
@@ -72,7 +72,7 @@ dependencies {
     implementation "com.google.code.gson:gson:2.8.9"
     implementation 'androidx.core:core-ktx:1.13.1'
     implementation "androidx.recyclerview:recyclerview:1.2.1"
-    implementation 'androidx.webkit:webkit:1.4.0'
+    implementation 'androidx.webkit:webkit:1.5.0'
 
     compileOnly "com.google.firebase:firebase-messaging:23.0.8"
 

--- a/hackle-android-sdk/src/main/java/io/hackle/android/ui/inappmessage/view/html/InAppMessageHtmlView.kt
+++ b/hackle-android-sdk/src/main/java/io/hackle/android/ui/inappmessage/view/html/InAppMessageHtmlView.kt
@@ -8,6 +8,8 @@ import android.os.Build
 import android.util.AttributeSet
 import android.webkit.WebView
 import androidx.webkit.WebViewAssetLoader
+import androidx.webkit.WebViewCompat
+import androidx.webkit.WebViewFeature
 import io.hackle.android.Hackle
 import io.hackle.android.R
 import io.hackle.android.app
@@ -73,6 +75,18 @@ internal class InAppMessageHtmlView @JvmOverloads constructor(
         val javascriptInterface = InAppMessageViewJavascriptInterface(Hackle.app, this)
         javascriptInterface.addTo(webView)
 
+        // Bridge script (Javascript SDK loader)
+        // On supported WebView, register the bridge to run at document start so that it is injected
+        // before any content script and regardless of whether onPageFinished fires.
+        // Otherwise, fall back to injecting on onPageFinished.
+        if (WebViewFeature.isFeatureSupported(WebViewFeature.DOCUMENT_START_SCRIPT)) {
+            WebViewCompat.addDocumentStartJavaScript(
+                webView,
+                bridgeScript.source,
+                setOf(InAppMessageWebView.ASSET_LOADER_BASE_URL)
+            )
+        }
+
         // WebView focus
         webView.setFocusableInTouchModeAndRequestFocus()
         if (Build.VERSION.SDK_INT >= Build.VERSION_CODES.O) {
@@ -116,7 +130,11 @@ internal class InAppMessageHtmlView @JvmOverloads constructor(
             if (state == InAppMessageView.State.CLOSED) {
                 return
             }
-            webView.evaluate(bridgeScript)
+            // On supported WebView, the bridge is already injected at document start.
+            // Only inject here as a fallback for WebView that does not support DOCUMENT_START_SCRIPT.
+            if (!WebViewFeature.isFeatureSupported(WebViewFeature.DOCUMENT_START_SCRIPT)) {
+                webView.evaluate(bridgeScript)
+            }
             webView.post { webView.requestFocus() }
             readyListener.onReady()
         }


### PR DESCRIPTION
## 배경

인앱 메시지(HTML 타입)는 WebView에 HTML을 로드한 뒤, Hackle JS SDK를 `<script>` 태그로 주입하는 브릿지 스크립트를 실행해 native 브릿지를 연결합니다. 현재 이 주입은 `InAppMessageHtmlView`의 `onPageFinished` 콜백 **한 곳**에서만 일어납니다.

이 구조의 문제:
- **주입 시점이 가장 늦음** — 페이지·하위 리소스 로딩이 전부 끝나야 주입이 시작되어, 무거운 리소스가 있으면 SDK 로드가 그만큼 지연됨
- **순서 보장 없음** — 콘텐츠 인라인 스크립트가 `onPageFinished` 이전에 실행되어 그 시점엔 `Hackle`이 없음
- **가장 심각**: `onPageFinished`가 발화하지 않으면(렌더 프로세스 종료, 행잉 리소스 등) **SDK가 아예 주입되지 않음**. 한편 `InAppMessageViewController`의 5초 타임아웃은 `open()` 시점부터 카운트되어 onReady와 무관하게 IAM을 띄우므로, **"SDK 없는 깡통 IAM"**이 표시될 수 있음

## 변경 내용

- 지원 WebView에서는 `WebViewCompat.addDocumentStartJavaScript`로 브릿지를 **문서 시작 시점에 등록** → 콘텐츠 스크립트보다 먼저, `onPageFinished` 발화 여부와 무관하게 주입 보장
- 미지원 WebView에서는 `onPageFinished`에서 기존대로 주입(폴백)
- 중복 주입 방지는 결정론적인 `WebViewFeature.isFeatureSupported(DOCUMENT_START_SCRIPT)` 분기로 처리(별도 상태 플래그 없음)
- `androidx.webkit` 1.4.0 → 1.5.0 (`addDocumentStartJavaScript` 제공 최소 버전)

### 변경하지 않은 것
- JS SDK 파일(`hackle-javascript-sdk-*.min.js`) 및 브릿지 JS 스니펫(`InAppMessageHtmlBridgeUserScript.source`)
- `onReady` / 5초 타임아웃 로직(`InAppMessageViewController`)
- `build.gradle`의 다른 의존성

### 참고: WebView 105 / DOCUMENT_START_SCRIPT 지원 범위

| 항목 | 내용 |
|---|---|
| 필요 WebView 버전 | Chromium **105+** |
| 105 출시 | **2022년 9월** (Android Chrome/WebView 9/15) → 현재 약 3년 9개월 경과 |
| 현재 최신 버전 | Chromium 150 |
