### PR TITLE
fix: HTML in-app message readiness and failure handling

### DIFF
--- a/hackle-android-sdk/src/main/java/io/hackle/android/ui/core/WebViewUserScript.kt
+++ b/hackle-android-sdk/src/main/java/io/hackle/android/ui/core/WebViewUserScript.kt
@@ -6,7 +6,9 @@ internal interface WebViewUserScript {
     val source: String
 }
 
-internal fun WebView.evaluate(script: WebViewUserScript) {
+internal fun WebView.evaluate(script: WebViewUserScript, completion: ((String?) -> Unit)? = null) {
     val source = script.source
-    evaluateJavascript(source, null)
+    evaluateJavascript(source) { value ->
+        completion?.invoke(value)
+    }
 }

--- a/hackle-android-sdk/src/main/java/io/hackle/android/ui/inappmessage/view/InAppMessageViewController.kt
+++ b/hackle-android-sdk/src/main/java/io/hackle/android/ui/inappmessage/view/InAppMessageViewController.kt
@@ -12,8 +12,6 @@ import io.hackle.android.ui.inappmessage.InAppMessageLifecycle.*
 import io.hackle.android.ui.inappmessage.event.InAppMessageViewEvent
 import io.hackle.android.ui.inappmessage.view.InAppMessageView.State
 import io.hackle.sdk.core.internal.log.Logger
-import io.hackle.sdk.core.internal.scheduler.ScheduledJob
-import java.util.concurrent.TimeUnit.MILLISECONDS
 import java.util.concurrent.atomic.AtomicReference
 
 
@@ -25,7 +23,6 @@ internal class InAppMessageViewController(
     private val _state = AtomicReference(State.CREATED)
     val state: State get() = _state.get()
 
-    private var openingTimeout: ScheduledJob? = null
     private var originalOrientation: Int? = null
 
     override fun open(activity: Activity) {
@@ -34,18 +31,12 @@ internal class InAppMessageViewController(
             return
         }
 
-        setTimeout {
-            runOnUiThread { present(activity) }
-        }
-
         view.configure {
             runOnUiThread { present(activity) }
         }
     }
 
     private fun present(activity: Activity) {
-        clearTimeout()
-
         if (!_state.compareAndSet(State.OPENING, State.OPENED)) {
             log.debug { "InAppMessage is not opening (state=${state}, key=${view.inAppMessage.key})" }
             return
@@ -66,8 +57,6 @@ internal class InAppMessageViewController(
     }
 
     override fun close(whenActivityDestroy: Boolean) {
-        clearTimeout()
-
         val prev: State = _state.getAndSet(State.CLOSED)
         return when (prev) {
             State.CREATED, State.OPENING -> {
@@ -87,15 +76,6 @@ internal class InAppMessageViewController(
                 log.debug { "InAppMessage is already closed (key=${view.inAppMessage.key})" }
             }
         }
-    }
-
-    private fun setTimeout(fallback: () -> Unit) {
-        openingTimeout = ui.scheduler.schedule(TIMEOUT_MILLIS, MILLISECONDS, fallback)
-    }
-
-    private fun clearTimeout() {
-        openingTimeout?.cancel()
-        openingTimeout = null
     }
 
     private fun closeWithoutViewRemove() {
@@ -166,7 +146,5 @@ internal class InAppMessageViewController(
 
     companion object {
         private val log = Logger<InAppMessageViewController>()
-
-        private const val TIMEOUT_MILLIS: Long = 5000
     }
 }

--- a/hackle-android-sdk/src/main/java/io/hackle/android/ui/inappmessage/view/InAppMessageWebViewClient.kt
+++ b/hackle-android-sdk/src/main/java/io/hackle/android/ui/inappmessage/view/InAppMessageWebViewClient.kt
@@ -38,7 +38,7 @@ internal class InAppMessageWebViewClient(
     @RequiresApi(Build.VERSION_CODES.M)
     override fun onReceivedError(view: WebView, request: WebResourceRequest, error: WebResourceError) {
         if (request.isForMainFrame) {
-            log.debug { "WebView received error on main frame: ${error.errorCode}" }
+            log.warn { "InAppMessageWebView received error on main frame: ${error.errorCode}" }
             listener.onPageError()
         }
     }
@@ -46,14 +46,14 @@ internal class InAppMessageWebViewClient(
     @Suppress("DEPRECATION")
     override fun onReceivedError(view: WebView, errorCode: Int, description: String?, failingUrl: String?) {
         // API 21-22: deprecated 콜백은 메인 프레임(메인 리소스) 에러에만 호출된다
-        log.debug { "WebView received error on main frame: $errorCode" }
+        log.warn { "InAppMessageWebView received error on main frame: $errorCode" }
         listener.onPageError()
     }
 
     @RequiresApi(Build.VERSION_CODES.O)
     override fun onRenderProcessGone(view: WebView, detail: RenderProcessGoneDetail): Boolean {
-        log.debug { "WebView's render process has exited." }
-        listener.onPageError()
+        log.warn { "InAppMessageWebView render process has exited: ${detail.didCrash()}" }
+        listener.onRenderProcessGone()
         return true
     }
 
@@ -61,6 +61,7 @@ internal class InAppMessageWebViewClient(
         fun onPageFinished(view: WebView, url: String)
         fun onUrlLoading(url: String): Boolean
         fun onPageError()
+        fun onRenderProcessGone()
     }
 
     companion object {

--- a/hackle-android-sdk/src/main/java/io/hackle/android/ui/inappmessage/view/InAppMessageWebViewClient.kt
+++ b/hackle-android-sdk/src/main/java/io/hackle/android/ui/inappmessage/view/InAppMessageWebViewClient.kt
@@ -35,15 +35,32 @@ internal class InAppMessageWebViewClient(
         return listener.onUrlLoading(url)
     }
 
+    @RequiresApi(Build.VERSION_CODES.M)
+    override fun onReceivedError(view: WebView, request: WebResourceRequest, error: WebResourceError) {
+        if (request.isForMainFrame) {
+            log.debug { "WebView received error on main frame: ${error.errorCode}" }
+            listener.onPageError()
+        }
+    }
+
+    @Suppress("DEPRECATION")
+    override fun onReceivedError(view: WebView, errorCode: Int, description: String?, failingUrl: String?) {
+        // API 21-22: deprecated 콜백은 메인 프레임(메인 리소스) 에러에만 호출된다
+        log.debug { "WebView received error on main frame: $errorCode" }
+        listener.onPageError()
+    }
+
     @RequiresApi(Build.VERSION_CODES.O)
     override fun onRenderProcessGone(view: WebView, detail: RenderProcessGoneDetail): Boolean {
         log.debug { "WebView's render process has exited." }
+        listener.onPageError()
         return true
     }
 
     interface PageListener {
         fun onPageFinished(view: WebView, url: String)
         fun onUrlLoading(url: String): Boolean
+        fun onPageError()
     }
 
     companion object {

--- a/hackle-android-sdk/src/main/java/io/hackle/android/ui/inappmessage/view/html/InAppMessageHtmlContentResolver.kt
+++ b/hackle-android-sdk/src/main/java/io/hackle/android/ui/inappmessage/view/html/InAppMessageHtmlContentResolver.kt
@@ -5,6 +5,7 @@ import io.hackle.sdk.core.model.InAppMessage
 import okhttp3.OkHttpClient
 import okhttp3.Request
 import okhttp3.Response
+import java.util.concurrent.TimeUnit
 
 internal interface InAppMessageHtmlContentResolver<HTML : InAppMessage.Message.Html> {
     fun supports(resourceType: InAppMessage.Message.Html.ResourceType): Boolean
@@ -49,7 +50,9 @@ internal class PathInAppMessageHtmlContentResolver(
 
     private fun execute(request: Request): Response {
         return ApiCallMetrics.record("get.iam-html") {
-            httpClient.newCall(request).execute()
+            val call = httpClient.newCall(request)
+            call.timeout().timeout(TIMEOUT_SECONDS, TimeUnit.SECONDS)
+            call.execute()
         }
     }
 
@@ -57,5 +60,9 @@ internal class PathInAppMessageHtmlContentResolver(
         check(response.isSuccessful) { "Http status code: ${response.code}" }
         val responseBody = checkNotNull(response.body) { "Response body is null" }
         return responseBody.string()
+    }
+
+    companion object {
+        private const val TIMEOUT_SECONDS = 5L
     }
 }

--- a/hackle-android-sdk/src/main/java/io/hackle/android/ui/inappmessage/view/html/InAppMessageHtmlReadyHandler.kt
+++ b/hackle-android-sdk/src/main/java/io/hackle/android/ui/inappmessage/view/html/InAppMessageHtmlReadyHandler.kt
@@ -1,0 +1,15 @@
+package io.hackle.android.ui.inappmessage.view.html
+
+internal class InAppMessageHtmlReadyHandler(
+    private val isClosed: () -> Boolean,
+    private val requestFocus: () -> Unit,
+    private val ready: () -> Unit,
+) {
+    fun onBridgeEvaluated() {
+        if (isClosed()) {
+            return
+        }
+        requestFocus()
+        ready()
+    }
+}

--- a/hackle-android-sdk/src/main/java/io/hackle/android/ui/inappmessage/view/html/InAppMessageHtmlView.kt
+++ b/hackle-android-sdk/src/main/java/io/hackle/android/ui/inappmessage/view/html/InAppMessageHtmlView.kt
@@ -6,6 +6,7 @@ import android.content.Context
 import android.graphics.Color
 import android.os.Build
 import android.util.AttributeSet
+import android.view.ViewGroup
 import android.webkit.WebView
 import androidx.webkit.WebViewAssetLoader
 import io.hackle.android.Hackle
@@ -52,7 +53,6 @@ internal class InAppMessageHtmlView @JvmOverloads constructor(
     private var _assetLoader: WebViewAssetLoader? = null
     private val assetLoader get() = requireNotNull(_assetLoader) { "WebViewAssetLoader is not set on InAppMessageHtmlView." }
 
-    // Closes the in-app message if the WebView never reports load completion or failure.
     private var loadTimeoutJob: ScheduledJob? = null
 
     @SuppressLint("SetJavaScriptEnabled")
@@ -94,6 +94,9 @@ internal class InAppMessageHtmlView @JvmOverloads constructor(
             val contentResolver = contentResolverFactory.get(html.resourceType)
             val content = contentResolver.resolve(html) // blocking
             runOnUiThread {
+                if (state != InAppMessageView.State.OPENING) {
+                    return@runOnUiThread
+                }
                 scheduleLoadTimeout()
                 webView.load(content)
             }
@@ -123,7 +126,7 @@ internal class InAppMessageHtmlView @JvmOverloads constructor(
         if (state != InAppMessageView.State.OPENING) {
             return
         }
-        log.warn { "InAppMessage HTML did not finish loading within ${LOAD_TIMEOUT_MILLIS}ms; closing [${inAppMessage.id}]" }
+        log.warn { "InAppMessage HTML did not become ready within ${LOAD_TIMEOUT_MILLIS}ms; closing [${inAppMessage.id}]" }
         close()
     }
 
@@ -137,20 +140,20 @@ internal class InAppMessageHtmlView @JvmOverloads constructor(
          * - Notifies that the InAppMessageView is ready to be shown.
          */
         override fun onPageFinished(view: WebView, url: String) {
-            cancelLoadTimeout()
             if (state == InAppMessageView.State.CLOSED) {
                 return
             }
 
             val readyHandler = InAppMessageHtmlReadyHandler(
                 isClosed = { state == InAppMessageView.State.CLOSED },
-                // Use setFocusableInTouchModeAndRequestFocus(): a bare requestFocus() is a no-op in touch
-                // mode unless the view is focusable-in-touch-mode. Since the configure-time focus setup is
-                // removed, focusability must be (re)established here or HTML form/keyboard focus breaks.
                 requestFocus = { webView.post { webView.setFocusableInTouchModeAndRequestFocus() } },
                 ready = { readyListener.onReady() }
             )
-            webView.evaluate(bridgeScript) { readyHandler.onBridgeEvaluated() }
+
+            webView.evaluate(bridgeScript) {
+                cancelLoadTimeout()
+                readyHandler.onBridgeEvaluated()
+            }
         }
 
         override fun onUrlLoading(url: String): Boolean {
@@ -161,6 +164,11 @@ internal class InAppMessageHtmlView @JvmOverloads constructor(
         }
 
         override fun onPageError() {
+            cancelLoadTimeout()
+            close()
+        }
+
+        override fun onRenderProcessGone() {
             cancelLoadTimeout()
             close()
         }

--- a/hackle-android-sdk/src/main/java/io/hackle/android/ui/inappmessage/view/html/InAppMessageHtmlView.kt
+++ b/hackle-android-sdk/src/main/java/io/hackle/android/ui/inappmessage/view/html/InAppMessageHtmlView.kt
@@ -177,7 +177,7 @@ internal class InAppMessageHtmlView @JvmOverloads constructor(
     companion object {
         private val log = Logger<InAppMessageHtmlView>()
 
-        private const val LOAD_TIMEOUT_MILLIS: Long = 5000
+        private const val LOAD_TIMEOUT_MILLIS: Long = 30000
 
         @SuppressLint("InflateParams")
         fun create(

--- a/hackle-android-sdk/src/main/java/io/hackle/android/ui/inappmessage/view/html/InAppMessageHtmlView.kt
+++ b/hackle-android-sdk/src/main/java/io/hackle/android/ui/inappmessage/view/html/InAppMessageHtmlView.kt
@@ -74,7 +74,6 @@ internal class InAppMessageHtmlView @JvmOverloads constructor(
         javascriptInterface.addTo(webView)
 
         // WebView focus
-        webView.setFocusableInTouchModeAndRequestFocus()
         if (Build.VERSION.SDK_INT >= Build.VERSION_CODES.O) {
             webView.isFocusedByDefault = true
         }
@@ -116,9 +115,16 @@ internal class InAppMessageHtmlView @JvmOverloads constructor(
             if (state == InAppMessageView.State.CLOSED) {
                 return
             }
-            webView.evaluate(bridgeScript)
-            webView.post { webView.requestFocus() }
-            readyListener.onReady()
+
+            val readyHandler = InAppMessageHtmlReadyHandler(
+                isClosed = { state == InAppMessageView.State.CLOSED },
+                // Use setFocusableInTouchModeAndRequestFocus(): a bare requestFocus() is a no-op in touch
+                // mode unless the view is focusable-in-touch-mode. Since the configure-time focus setup is
+                // removed, focusability must be (re)established here or HTML form/keyboard focus breaks.
+                requestFocus = { webView.post { webView.setFocusableInTouchModeAndRequestFocus() } },
+                ready = { readyListener.onReady() }
+            )
+            webView.evaluate(bridgeScript) { readyHandler.onBridgeEvaluated() }
         }
 
         override fun onUrlLoading(url: String): Boolean {
@@ -126,6 +132,10 @@ internal class InAppMessageHtmlView @JvmOverloads constructor(
             val event = InAppMessageViewEvent.action(this@InAppMessageHtmlView, action, null)
             handle(event, InAppMessageViewEventHandleType.ACTION)
             return true
+        }
+
+        override fun onPageError() {
+            close()
         }
     }
 

--- a/hackle-android-sdk/src/main/java/io/hackle/android/ui/inappmessage/view/html/InAppMessageHtmlView.kt
+++ b/hackle-android-sdk/src/main/java/io/hackle/android/ui/inappmessage/view/html/InAppMessageHtmlView.kt
@@ -20,7 +20,9 @@ import io.hackle.android.ui.inappmessage.event.InAppMessageViewEvent
 import io.hackle.android.ui.inappmessage.event.InAppMessageViewEventHandleType
 import io.hackle.android.ui.inappmessage.view.*
 import io.hackle.sdk.core.internal.log.Logger
+import io.hackle.sdk.core.internal.scheduler.ScheduledJob
 import io.hackle.sdk.core.model.InAppMessage
+import java.util.concurrent.TimeUnit.MILLISECONDS
 
 /**
  * In-app message view that renders HTML content via WebView.
@@ -49,6 +51,9 @@ internal class InAppMessageHtmlView @JvmOverloads constructor(
 
     private var _assetLoader: WebViewAssetLoader? = null
     private val assetLoader get() = requireNotNull(_assetLoader) { "WebViewAssetLoader is not set on InAppMessageHtmlView." }
+
+    // Closes the in-app message if the WebView never reports load completion or failure.
+    private var loadTimeoutJob: ScheduledJob? = null
 
     @SuppressLint("SetJavaScriptEnabled")
     override fun onConfigure(listener: InAppMessageView.ReadyListener) {
@@ -89,6 +94,7 @@ internal class InAppMessageHtmlView @JvmOverloads constructor(
             val contentResolver = contentResolverFactory.get(html.resourceType)
             val content = contentResolver.resolve(html) // blocking
             runOnUiThread {
+                scheduleLoadTimeout()
                 webView.load(content)
             }
         } catch (e: Exception) {
@@ -102,6 +108,25 @@ internal class InAppMessageHtmlView @JvmOverloads constructor(
         webView.removeAllViews()
     }
 
+    private fun scheduleLoadTimeout() {
+        loadTimeoutJob = controller.ui.scheduler.schedule(LOAD_TIMEOUT_MILLIS, MILLISECONDS) {
+            runOnUiThread { onLoadTimeout() }
+        }
+    }
+
+    private fun cancelLoadTimeout() {
+        loadTimeoutJob?.cancel()
+        loadTimeoutJob = null
+    }
+
+    private fun onLoadTimeout() {
+        if (state != InAppMessageView.State.OPENING) {
+            return
+        }
+        log.warn { "InAppMessage HTML did not finish loading within ${LOAD_TIMEOUT_MILLIS}ms; closing [${inAppMessage.id}]" }
+        close()
+    }
+
     inner class HtmlPageListener(
         private val readyListener: InAppMessageView.ReadyListener
     ) : InAppMessageWebViewClient.PageListener {
@@ -112,6 +137,7 @@ internal class InAppMessageHtmlView @JvmOverloads constructor(
          * - Notifies that the InAppMessageView is ready to be shown.
          */
         override fun onPageFinished(view: WebView, url: String) {
+            cancelLoadTimeout()
             if (state == InAppMessageView.State.CLOSED) {
                 return
             }
@@ -135,12 +161,15 @@ internal class InAppMessageHtmlView @JvmOverloads constructor(
         }
 
         override fun onPageError() {
+            cancelLoadTimeout()
             close()
         }
     }
 
     companion object {
         private val log = Logger<InAppMessageHtmlView>()
+
+        private const val LOAD_TIMEOUT_MILLIS: Long = 5000
 
         @SuppressLint("InflateParams")
         fun create(

--- a/hackle-android-sdk/src/test/java/io/hackle/android/support/Models.kt
+++ b/hackle-android-sdk/src/test/java/io/hackle/android/support/Models.kt
@@ -140,6 +140,7 @@ internal object InAppMessages {
         action: InAppMessage.Action? = null,
         outerButtons: List<InAppMessage.Message.PositionalButton> = emptyList(),
         innerButtons: List<InAppMessage.Message.PositionalButton> = emptyList(),
+        html: InAppMessage.Message.Html? = null,
     ): InAppMessage.Message {
         return InAppMessage.Message(
             variationKey = variationKey,
@@ -154,7 +155,7 @@ internal object InAppMessages {
             action = action,
             outerButtons = outerButtons,
             innerButtons = innerButtons,
-            html = null,
+            html = html,
         )
     }
 

--- a/hackle-android-sdk/src/test/java/io/hackle/android/ui/core/WebViewUserScriptTest.kt
+++ b/hackle-android-sdk/src/test/java/io/hackle/android/ui/core/WebViewUserScriptTest.kt
@@ -1,0 +1,35 @@
+package io.hackle.android.ui.core
+
+import android.webkit.ValueCallback
+import android.webkit.WebView
+import io.mockk.every
+import io.mockk.mockk
+import io.mockk.slot
+import io.mockk.verify
+import org.junit.Test
+import strikt.api.expectThat
+import strikt.assertions.isEqualTo
+
+internal class WebViewUserScriptTest {
+
+    @Test
+    fun `evaluate passes completion to WebView evaluateJavascript`() {
+        val webView = mockk<WebView>(relaxed = true)
+        val callbackSlot = slot<ValueCallback<String>>()
+        val script = object : WebViewUserScript {
+            override val source: String = "1 + 1"
+        }
+        var completedWith: String? = null
+
+        every { webView.evaluateJavascript("1 + 1", capture(callbackSlot)) } answers {
+            callbackSlot.captured.onReceiveValue("2")
+        }
+
+        webView.evaluate(script) { value ->
+            completedWith = value
+        }
+
+        verify(exactly = 1) { webView.evaluateJavascript("1 + 1", any()) }
+        expectThat(completedWith).isEqualTo("2")
+    }
+}

--- a/hackle-android-sdk/src/test/java/io/hackle/android/ui/inappmessage/view/InAppMessageViewControllerTest.kt
+++ b/hackle-android-sdk/src/test/java/io/hackle/android/ui/inappmessage/view/InAppMessageViewControllerTest.kt
@@ -1,0 +1,127 @@
+package io.hackle.android.ui.inappmessage.view
+
+import android.app.Activity
+import android.content.Context
+import io.hackle.android.internal.inappmessage.present.presentation.InAppMessagePresentationContext
+import io.hackle.android.internal.task.TaskExecutors
+import io.hackle.android.support.InAppMessages
+import io.hackle.android.ui.inappmessage.InAppMessageLifecycle
+import io.hackle.android.ui.inappmessage.InAppMessageUi
+import io.hackle.sdk.core.internal.scheduler.ScheduledJob
+import io.hackle.sdk.core.internal.scheduler.Scheduler
+import io.hackle.sdk.core.model.InAppMessage
+import io.mockk.every
+import io.mockk.mockk
+import io.mockk.mockkObject
+import io.mockk.unmockkObject
+import io.mockk.verify
+import org.junit.After
+import org.junit.Before
+import org.junit.Test
+import strikt.api.expectThat
+import strikt.assertions.isFalse
+import java.util.concurrent.TimeUnit
+
+internal class InAppMessageViewControllerTest {
+
+    private lateinit var scheduler: TestScheduler
+    private lateinit var ui: InAppMessageUi
+    private lateinit var activity: Activity
+
+    @Before
+    fun before() {
+        mockkObject(TaskExecutors)
+        every { TaskExecutors.runOnUiThread(any()) } answers { firstArg<() -> Unit>()() }
+
+        scheduler = TestScheduler()
+        ui = mockk(relaxed = true)
+        every { ui.scheduler } returns scheduler
+
+        activity = mockk(relaxed = true)
+    }
+
+    @After
+    fun after() {
+        unmockkObject(TaskExecutors)
+    }
+
+    @Test
+    fun `open does not schedule opening timeout`() {
+        val view = TestInAppMessageView(activity, context(displayType = InAppMessage.DisplayType.HTML))
+        val sut = InAppMessageViewController(view, ui)
+        view.setController(sut)
+
+        sut.open(activity)
+
+        expectThat(scheduler.hasScheduledTask).isFalse()
+    }
+
+    private fun context(displayType: InAppMessage.DisplayType): InAppMessagePresentationContext {
+        val message = InAppMessages.message(
+            layout = InAppMessages.layout(
+                displayType = displayType,
+                layoutType = if (displayType == InAppMessage.DisplayType.HTML) {
+                    InAppMessage.LayoutType.NONE
+                } else {
+                    InAppMessage.LayoutType.IMAGE_ONLY
+                }
+            ),
+            html = if (displayType == InAppMessage.DisplayType.HTML) {
+                InAppMessage.Message.Html.TextHtml("<html></html>")
+            } else {
+                null
+            }
+        )
+        val inAppMessage = InAppMessages.create(
+            messageContext = InAppMessages.messageContext(messages = listOf(message))
+        )
+        return InAppMessages.context(inAppMessage = inAppMessage, message = message)
+    }
+
+    private class TestInAppMessageView(
+        context: Context,
+        presentationContext: InAppMessagePresentationContext,
+    ) : InAppMessageBaseView(context), InAppMessageView.LifecycleListener {
+
+        val lifecycles = mutableListOf<InAppMessageLifecycle>()
+
+        override val openAnimator: InAppMessageAnimator? = null
+        override val closeAnimator: InAppMessageAnimator? = null
+
+        init {
+            setPresentationContext(presentationContext)
+        }
+
+        override fun onConfigure(listener: InAppMessageView.ReadyListener) {
+        }
+
+        override fun beforeInAppMessageOpen() {
+            lifecycles.add(InAppMessageLifecycle.BEFORE_OPEN)
+            throw IllegalStateException("stop after lifecycle")
+        }
+    }
+
+    private class TestScheduler : Scheduler {
+        private var scheduledTask: (() -> Unit)? = null
+        val hasScheduledTask: Boolean get() = scheduledTask != null
+
+        override fun schedule(delay: Long, unit: TimeUnit, task: () -> Unit): ScheduledJob {
+            scheduledTask = task
+            return TestScheduledJob()
+        }
+
+        override fun schedulePeriodically(
+            delay: Long,
+            period: Long,
+            unit: TimeUnit,
+            task: () -> Unit
+        ): ScheduledJob {
+            throw UnsupportedOperationException()
+        }
+    }
+
+    private class TestScheduledJob : ScheduledJob {
+        override fun cancel() {
+        }
+    }
+}

--- a/hackle-android-sdk/src/test/java/io/hackle/android/ui/inappmessage/view/InAppMessageWebViewClientTest.kt
+++ b/hackle-android-sdk/src/test/java/io/hackle/android/ui/inappmessage/view/InAppMessageWebViewClientTest.kt
@@ -47,12 +47,13 @@ internal class InAppMessageWebViewClientTest {
     }
 
     @Test
-    fun `onRenderProcessGone notifies page error and returns true`() {
+    fun `onRenderProcessGone notifies render process gone and returns true`() {
         val detail = mockk<RenderProcessGoneDetail>(relaxed = true)
 
         val result = sut.onRenderProcessGone(mockk(relaxed = true), detail)
 
-        verify(exactly = 1) { listener.onPageError() }
+        verify(exactly = 1) { listener.onRenderProcessGone() }
+        verify(exactly = 0) { listener.onPageError() }
         expectThat(result).isTrue()
     }
 }

--- a/hackle-android-sdk/src/test/java/io/hackle/android/ui/inappmessage/view/InAppMessageWebViewClientTest.kt
+++ b/hackle-android-sdk/src/test/java/io/hackle/android/ui/inappmessage/view/InAppMessageWebViewClientTest.kt
@@ -1,0 +1,58 @@
+package io.hackle.android.ui.inappmessage.view
+
+import android.webkit.RenderProcessGoneDetail
+import android.webkit.WebResourceError
+import android.webkit.WebResourceRequest
+import android.webkit.WebView
+import androidx.webkit.WebViewAssetLoader
+import io.mockk.every
+import io.mockk.mockk
+import io.mockk.verify
+import org.junit.Test
+import strikt.api.expectThat
+import strikt.assertions.isTrue
+
+internal class InAppMessageWebViewClientTest {
+
+    private val assetLoader = mockk<WebViewAssetLoader>(relaxed = true)
+    private val listener = mockk<InAppMessageWebViewClient.PageListener>(relaxed = true)
+    private val sut = InAppMessageWebViewClient(assetLoader, listener)
+
+    @Test
+    fun `onReceivedError on main frame notifies page error`() {
+        val request = mockk<WebResourceRequest> { every { isForMainFrame } returns true }
+        val error = mockk<WebResourceError>(relaxed = true)
+
+        sut.onReceivedError(mockk(relaxed = true), request, error)
+
+        verify(exactly = 1) { listener.onPageError() }
+    }
+
+    @Test
+    fun `onReceivedError on sub resource is ignored`() {
+        val request = mockk<WebResourceRequest> { every { isForMainFrame } returns false }
+        val error = mockk<WebResourceError>(relaxed = true)
+
+        sut.onReceivedError(mockk(relaxed = true), request, error)
+
+        verify(exactly = 0) { listener.onPageError() }
+    }
+
+    @Test
+    fun `deprecated onReceivedError notifies page error`() {
+        @Suppress("DEPRECATION")
+        sut.onReceivedError(mockk(relaxed = true), -1, "error", "https://example.com")
+
+        verify(exactly = 1) { listener.onPageError() }
+    }
+
+    @Test
+    fun `onRenderProcessGone notifies page error and returns true`() {
+        val detail = mockk<RenderProcessGoneDetail>(relaxed = true)
+
+        val result = sut.onRenderProcessGone(mockk(relaxed = true), detail)
+
+        verify(exactly = 1) { listener.onPageError() }
+        expectThat(result).isTrue()
+    }
+}

--- a/hackle-android-sdk/src/test/java/io/hackle/android/ui/inappmessage/view/html/InAppMessageHtmlContentResolverTest.kt
+++ b/hackle-android-sdk/src/test/java/io/hackle/android/ui/inappmessage/view/html/InAppMessageHtmlContentResolverTest.kt
@@ -1,0 +1,76 @@
+package io.hackle.android.ui.inappmessage.view.html
+
+import io.hackle.sdk.core.model.InAppMessage
+import io.mockk.every
+import io.mockk.mockk
+import io.mockk.verify
+import okhttp3.Call
+import okhttp3.MediaType.Companion.toMediaType
+import okhttp3.OkHttpClient
+import okhttp3.Protocol
+import okhttp3.Request
+import okhttp3.Response
+import okhttp3.ResponseBody.Companion.toResponseBody
+import okio.Timeout
+import org.junit.Test
+import strikt.api.expectThat
+import strikt.assertions.isEqualTo
+import java.io.InterruptedIOException
+import java.util.concurrent.TimeUnit
+
+internal class InAppMessageHtmlContentResolverTest {
+
+    @Test
+    fun `text resolver returns inline html without http timeout`() {
+        val sut = TextInAppMessageHtmlContentResolver()
+        val html = InAppMessage.Message.Html.TextHtml("<html>inline</html>")
+
+        val actual = sut.resolve(html)
+
+        expectThat(actual).isEqualTo("<html>inline</html>")
+    }
+
+    @Test
+    fun `path resolver applies five second timeout to remote html call`() {
+        val httpClient = mockk<OkHttpClient>()
+        val call = mockk<Call>()
+        val timeout = mockk<Timeout>(relaxed = true)
+        val requestSlot = mutableListOf<Request>()
+        val response = Response.Builder()
+            .request(Request.Builder().url("https://example.com/iam.html").build())
+            .protocol(Protocol.HTTP_1_1)
+            .code(200)
+            .message("OK")
+            .body("<html>remote</html>".toResponseBody("text/html".toMediaType()))
+            .build()
+
+        every { httpClient.newCall(capture(requestSlot)) } returns call
+        every { call.timeout() } returns timeout
+        every { timeout.timeout(5, TimeUnit.SECONDS) } returns timeout
+        every { call.execute() } returns response
+
+        val sut = PathInAppMessageHtmlContentResolver(httpClient)
+        val actual = sut.resolve(InAppMessage.Message.Html.PathHtml("https://example.com/iam.html"))
+
+        expectThat(actual).isEqualTo("<html>remote</html>")
+        expectThat(requestSlot.single().url.toString()).isEqualTo("https://example.com/iam.html")
+        verify(exactly = 1) { timeout.timeout(5, TimeUnit.SECONDS) }
+        verify(exactly = 1) { call.execute() }
+    }
+
+    @Test(expected = InterruptedIOException::class)
+    fun `path resolver propagates remote html timeout`() {
+        val httpClient = mockk<OkHttpClient>()
+        val call = mockk<Call>()
+        val timeout = mockk<Timeout>(relaxed = true)
+
+        every { httpClient.newCall(any()) } returns call
+        every { call.timeout() } returns timeout
+        every { timeout.timeout(5, TimeUnit.SECONDS) } returns timeout
+        every { call.execute() } throws InterruptedIOException("timeout")
+
+        val sut = PathInAppMessageHtmlContentResolver(httpClient)
+
+        sut.resolve(InAppMessage.Message.Html.PathHtml("https://example.com/iam.html"))
+    }
+}

--- a/hackle-android-sdk/src/test/java/io/hackle/android/ui/inappmessage/view/html/InAppMessageHtmlReadyHandlerTest.kt
+++ b/hackle-android-sdk/src/test/java/io/hackle/android/ui/inappmessage/view/html/InAppMessageHtmlReadyHandlerTest.kt
@@ -1,0 +1,22 @@
+package io.hackle.android.ui.inappmessage.view.html
+
+import org.junit.Test
+import strikt.api.expectThat
+import strikt.assertions.isEmpty
+
+internal class InAppMessageHtmlReadyHandlerTest {
+
+    @Test
+    fun `when view is closed then bridge evaluation completion is ignored`() {
+        val events = mutableListOf<String>()
+        val sut = InAppMessageHtmlReadyHandler(
+            isClosed = { true },
+            requestFocus = { events.add("focus") },
+            ready = { events.add("ready") }
+        )
+
+        sut.onBridgeEvaluated()
+
+        expectThat(events).isEmpty()
+    }
+}


### PR DESCRIPTION
## 개요
HTML 인앱 메시지의 준비(readiness) 및 실패(failure) 처리 로직을 개선합니다.
WebView 로드 실패 및 렌더 프로세스 종료 시 인앱 메시지를 닫도록 처리하고, 타임아웃 관리를 ViewController 레벨에서 View 레벨로 이동하였습니다.

## 작업 내용
- `InAppMessageWebViewClient`에 `onReceivedError`, `onRenderProcessGone` 에러 콜백 추가
- WebView 로드 타임아웃을 `InAppMessageHtmlView`에서 관리하도록 변경 (30초)
- HTTP 컨텐츠 요청 타임아웃 추가 (5초)
- Bridge 스크립트 평가 완료 후 WebView 포커스 설정 및 ready 신호 전달하도록 변경
- `InAppMessageHtmlReadyHandler` 클래스로 ready 처리 로직 분리