### PR TITLE
fix: remove NO_HISTORY from push deep link trampoline

### DIFF
--- a/hackle-android-sdk/src/main/java/io/hackle/android/ui/notification/NotificationTrampolineActivity.kt
+++ b/hackle-android-sdk/src/main/java/io/hackle/android/ui/notification/NotificationTrampolineActivity.kt
@@ -47,7 +47,7 @@ internal class NotificationTrampolineActivity : Activity() {
                 } else {
                     val trampolineIntent = Intent(Intent.ACTION_VIEW, uri)
                     trampolineIntent.putExtras(extras)
-                    trampolineIntent.flags = Intent.FLAG_ACTIVITY_NO_HISTORY
+                    trampolineIntent.flags = DEEP_LINK_INTENT_FLAGS
                     try {
                         startActivity(trampolineIntent)
                         log.debug { "Redirected to: $uri" }
@@ -79,5 +79,10 @@ internal class NotificationTrampolineActivity : Activity() {
     companion object {
 
         private val log = Logger<NotificationTrampolineActivity>()
+
+        internal val DEEP_LINK_INTENT_FLAGS =
+            Intent.FLAG_ACTIVITY_NEW_TASK or
+                Intent.FLAG_ACTIVITY_CLEAR_TOP or
+                Intent.FLAG_ACTIVITY_SINGLE_TOP
     }
 }

--- a/hackle-android-sdk/src/main/java/io/hackle/android/ui/notification/NotificationTrampolineActivity.kt
+++ b/hackle-android-sdk/src/main/java/io/hackle/android/ui/notification/NotificationTrampolineActivity.kt
@@ -47,7 +47,7 @@ internal class NotificationTrampolineActivity : Activity() {
                 } else {
                     val trampolineIntent = Intent(Intent.ACTION_VIEW, uri)
                     trampolineIntent.putExtras(extras)
-                    trampolineIntent.flags = DEEP_LINK_INTENT_FLAGS
+                    trampolineIntent.addFlags(NOTIFICATION_INTENT_FLAGS)
                     try {
                         startActivity(trampolineIntent)
                         log.debug { "Redirected to: $uri" }
@@ -67,9 +67,7 @@ internal class NotificationTrampolineActivity : Activity() {
             return
         }
         launcherIntent.setData(data)
-        launcherIntent.addFlags(Intent.FLAG_ACTIVITY_NEW_TASK)
-        launcherIntent.addFlags(Intent.FLAG_ACTIVITY_CLEAR_TOP)
-        launcherIntent.addFlags(Intent.FLAG_ACTIVITY_SINGLE_TOP)
+        launcherIntent.addFlags(NOTIFICATION_INTENT_FLAGS)
         launcherIntent.putExtras(bundle)
         startActivity(launcherIntent)
 
@@ -80,7 +78,7 @@ internal class NotificationTrampolineActivity : Activity() {
 
         private val log = Logger<NotificationTrampolineActivity>()
 
-        internal val DEEP_LINK_INTENT_FLAGS =
+        internal val NOTIFICATION_INTENT_FLAGS =
             Intent.FLAG_ACTIVITY_NEW_TASK or
                 Intent.FLAG_ACTIVITY_CLEAR_TOP or
                 Intent.FLAG_ACTIVITY_SINGLE_TOP

--- a/hackle-android-sdk/src/test/java/io/hackle/android/ui/notification/NotificationTrampolineActivityTest.kt
+++ b/hackle-android-sdk/src/test/java/io/hackle/android/ui/notification/NotificationTrampolineActivityTest.kt
@@ -1,8 +1,20 @@
 package io.hackle.android.ui.notification
 
 import android.content.Intent
+import android.content.pm.PackageManager
+import android.net.Uri
+import android.os.Bundle
+import io.mockk.every
+import io.mockk.mockk
+import io.mockk.mockkObject
+import io.mockk.spyk
+import io.mockk.unmockkAll
+import io.mockk.verify
+import org.junit.After
 import org.junit.Assert.assertEquals
+import org.junit.Before
 import org.junit.Test
+import java.lang.reflect.Method
 
 class NotificationTrampolineActivityTest {
 
@@ -22,5 +34,194 @@ class NotificationTrampolineActivityTest {
             NotificationTrampolineActivity.NOTIFICATION_INTENT_FLAGS and Intent.FLAG_ACTIVITY_NO_HISTORY
 
         assertEquals(0, noHistoryBit)
+    }
+
+    // ---------------------------------------------------------------------------
+    // Behavioral tests — verify that addFlags(NOTIFICATION_INTENT_FLAGS) is called
+    // on the destination intent for each code path.
+    // ---------------------------------------------------------------------------
+
+    private lateinit var sut: NotificationTrampolineActivity
+    private lateinit var activityIntent: Intent
+    private lateinit var extras: Bundle
+    private lateinit var notificationData: NotificationData
+    private lateinit var notificationHandler: NotificationHandler
+
+    @Before
+    fun setUp() {
+        // Stub NotificationData.from so we don't need real extras parsing.
+        mockkObject(NotificationData.Companion)
+        mockkObject(NotificationHandler.Companion)
+
+        extras = mockk(relaxed = true)
+        notificationData = mockk(relaxed = true)
+
+        notificationHandler = mockk(relaxed = true)
+        every { NotificationHandler.getInstance(any()) } returns notificationHandler
+
+        // Build the spy AFTER mockkObject so companion stubs are in place.
+        sut = spyk(NotificationTrampolineActivity(), recordPrivateCalls = true)
+
+        // Stub Activity lifecycle / context accessors used inside onCreate / trampoline.
+        every { sut.finish() } returns Unit
+        every { sut.startActivity(any()) } returns Unit
+    }
+
+    @After
+    fun tearDown() {
+        unmockkAll()
+    }
+
+    /**
+     * Helper: wire sut.intent to return a mock intent whose extras and data are controlled.
+     */
+    private fun stubActivityIntent(uri: Uri? = null): Intent {
+        activityIntent = mockk(relaxed = true)
+        every { activityIntent.extras } returns extras
+        every { activityIntent.data } returns uri
+        every { sut.intent } returns activityIntent
+        return activityIntent
+    }
+
+    /**
+     * Helper: invoke the protected onCreate via reflection to bypass Kotlin visibility rules.
+     */
+    private fun callOnCreate() {
+        val method: Method = NotificationTrampolineActivity::class.java
+            .getDeclaredMethod("onCreate", android.os.Bundle::class.java)
+        method.isAccessible = true
+        method.invoke(sut, null as android.os.Bundle?)
+    }
+
+    // ------------------------------------------------------------------
+    // APP_OPEN path → startLauncherActivity → launcherIntent.addFlags(NOTIFICATION_INTENT_FLAGS)
+    // ------------------------------------------------------------------
+
+    @Test
+    fun `APP_OPEN path - launcher intent receives NOTIFICATION_INTENT_FLAGS`() {
+        stubActivityIntent(uri = null)
+
+        every { notificationData.clickAction } returns NotificationClickAction.APP_OPEN
+        every { NotificationData.from(any()) } returns notificationData
+
+        val launcherIntent = mockk<Intent>(relaxed = true)
+        val packageManager = mockk<PackageManager>(relaxed = true)
+        every { packageManager.getLaunchIntentForPackage(any()) } returns launcherIntent
+        every { sut.packageManager } returns packageManager
+        every { sut.packageName } returns "io.hackle.test"
+
+        callOnCreate()
+
+        verify(exactly = 1) { launcherIntent.addFlags(NotificationTrampolineActivity.NOTIFICATION_INTENT_FLAGS) }
+        verify(exactly = 1) { sut.startActivity(launcherIntent) }
+    }
+
+    // ------------------------------------------------------------------
+    // DEEP_LINK path with uri present → Intent(ACTION_VIEW, uri).addFlags(NOTIFICATION_INTENT_FLAGS)
+    // ------------------------------------------------------------------
+
+    @Test
+    fun `DEEP_LINK path with uri - startActivity called directly without going through launcher`() {
+        val uri = mockk<Uri>(relaxed = true)
+        stubActivityIntent(uri = uri)
+
+        every { notificationData.clickAction } returns NotificationClickAction.DEEP_LINK
+        every { NotificationData.from(any()) } returns notificationData
+
+        // Stub packageManager as a sentinel: if getLaunchIntentForPackage is called,
+        // we know startLauncherActivity was invoked (wrong path for this test).
+        val packageManager = mockk<PackageManager>(relaxed = true)
+        every { sut.packageManager } returns packageManager
+        every { sut.packageName } returns "io.hackle.test"
+
+        callOnCreate()
+
+        // On the DEEP_LINK + uri path, startActivity is called exactly once with the
+        // ACTION_VIEW intent (not the launcher intent).
+        verify(exactly = 1) { sut.startActivity(any()) }
+        // The launcher path (packageManager) must NOT have been invoked.
+        verify(exactly = 0) { packageManager.getLaunchIntentForPackage(any()) }
+    }
+
+    // ------------------------------------------------------------------
+    // DEEP_LINK path with null uri → falls back to startLauncherActivity
+    // ------------------------------------------------------------------
+
+    @Test
+    fun `DEEP_LINK path with null uri - launcher intent receives NOTIFICATION_INTENT_FLAGS`() {
+        stubActivityIntent(uri = null)
+
+        every { notificationData.clickAction } returns NotificationClickAction.DEEP_LINK
+        every { NotificationData.from(any()) } returns notificationData
+
+        val launcherIntent = mockk<Intent>(relaxed = true)
+        val packageManager = mockk<PackageManager>(relaxed = true)
+        every { packageManager.getLaunchIntentForPackage(any()) } returns launcherIntent
+        every { sut.packageManager } returns packageManager
+        every { sut.packageName } returns "io.hackle.test"
+
+        callOnCreate()
+
+        verify(exactly = 1) { launcherIntent.addFlags(NotificationTrampolineActivity.NOTIFICATION_INTENT_FLAGS) }
+        verify(exactly = 1) { sut.startActivity(launcherIntent) }
+    }
+
+    // ------------------------------------------------------------------
+    // DEEP_LINK path with uri but ActivityNotFoundException → falls back to launcher
+    // ------------------------------------------------------------------
+
+    @Test
+    fun `DEEP_LINK path with uri and ActivityNotFoundException - launcher intent receives NOTIFICATION_INTENT_FLAGS`() {
+        val uri = mockk<Uri>(relaxed = true)
+        stubActivityIntent(uri = uri)
+
+        every { notificationData.clickAction } returns NotificationClickAction.DEEP_LINK
+        every { NotificationData.from(any()) } returns notificationData
+
+        val launcherIntent = mockk<Intent>(relaxed = true)
+        val packageManager = mockk<PackageManager>(relaxed = true)
+        every { packageManager.getLaunchIntentForPackage(any()) } returns launcherIntent
+        every { sut.packageManager } returns packageManager
+        every { sut.packageName } returns "io.hackle.test"
+
+        // First startActivity (deep link) throws ActivityNotFoundException; the launcher fallback succeeds.
+        var startActivityCallCount = 0
+        every { sut.startActivity(any()) } answers {
+            startActivityCallCount++
+            if (startActivityCallCount == 1) throw android.content.ActivityNotFoundException("no handler")
+            Unit
+        }
+
+        callOnCreate()
+
+        // Launcher intent must have received addFlags(NOTIFICATION_INTENT_FLAGS).
+        verify(exactly = 1) { launcherIntent.addFlags(NotificationTrampolineActivity.NOTIFICATION_INTENT_FLAGS) }
+    }
+
+    // ------------------------------------------------------------------
+    // Negative: verify NO_HISTORY bit is never in the flag value passed to addFlags
+    // ------------------------------------------------------------------
+
+    @Test
+    fun `APP_OPEN path - addFlags value does not include NO_HISTORY`() {
+        stubActivityIntent(uri = null)
+
+        every { notificationData.clickAction } returns NotificationClickAction.APP_OPEN
+        every { NotificationData.from(any()) } returns notificationData
+
+        val launcherIntent = mockk<Intent>(relaxed = true)
+        val packageManager = mockk<PackageManager>(relaxed = true)
+        every { packageManager.getLaunchIntentForPackage(any()) } returns launcherIntent
+        every { sut.packageManager } returns packageManager
+        every { sut.packageName } returns "io.hackle.test"
+
+        callOnCreate()
+
+        // Capture the flags value actually passed and assert it has no NO_HISTORY bit.
+        verify {
+            launcherIntent.addFlags(match { flags ->
+                (flags and Intent.FLAG_ACTIVITY_NO_HISTORY) == 0
+            })
+        }
     }
 }

--- a/hackle-android-sdk/src/test/java/io/hackle/android/ui/notification/NotificationTrampolineActivityTest.kt
+++ b/hackle-android-sdk/src/test/java/io/hackle/android/ui/notification/NotificationTrampolineActivityTest.kt
@@ -7,19 +7,19 @@ import org.junit.Test
 class NotificationTrampolineActivityTest {
 
     @Test
-    fun `deep link intent flags are NEW_TASK, CLEAR_TOP, SINGLE_TOP`() {
+    fun `notification intent flags are NEW_TASK, CLEAR_TOP, SINGLE_TOP`() {
         val expected =
             Intent.FLAG_ACTIVITY_NEW_TASK or
                 Intent.FLAG_ACTIVITY_CLEAR_TOP or
                 Intent.FLAG_ACTIVITY_SINGLE_TOP
 
-        assertEquals(expected, NotificationTrampolineActivity.DEEP_LINK_INTENT_FLAGS)
+        assertEquals(expected, NotificationTrampolineActivity.NOTIFICATION_INTENT_FLAGS)
     }
 
     @Test
-    fun `deep link intent flags must not contain NO_HISTORY`() {
+    fun `notification intent flags must not contain NO_HISTORY`() {
         val noHistoryBit =
-            NotificationTrampolineActivity.DEEP_LINK_INTENT_FLAGS and Intent.FLAG_ACTIVITY_NO_HISTORY
+            NotificationTrampolineActivity.NOTIFICATION_INTENT_FLAGS and Intent.FLAG_ACTIVITY_NO_HISTORY
 
         assertEquals(0, noHistoryBit)
     }

--- a/hackle-android-sdk/src/test/java/io/hackle/android/ui/notification/NotificationTrampolineActivityTest.kt
+++ b/hackle-android-sdk/src/test/java/io/hackle/android/ui/notification/NotificationTrampolineActivityTest.kt
@@ -1,0 +1,26 @@
+package io.hackle.android.ui.notification
+
+import android.content.Intent
+import org.junit.Assert.assertEquals
+import org.junit.Test
+
+class NotificationTrampolineActivityTest {
+
+    @Test
+    fun `deep link intent flags are NEW_TASK, CLEAR_TOP, SINGLE_TOP`() {
+        val expected =
+            Intent.FLAG_ACTIVITY_NEW_TASK or
+                Intent.FLAG_ACTIVITY_CLEAR_TOP or
+                Intent.FLAG_ACTIVITY_SINGLE_TOP
+
+        assertEquals(expected, NotificationTrampolineActivity.DEEP_LINK_INTENT_FLAGS)
+    }
+
+    @Test
+    fun `deep link intent flags must not contain NO_HISTORY`() {
+        val noHistoryBit =
+            NotificationTrampolineActivity.DEEP_LINK_INTENT_FLAGS and Intent.FLAG_ACTIVITY_NO_HISTORY
+
+        assertEquals(0, noHistoryBit)
+    }
+}


### PR DESCRIPTION
## 개요
푸시 딥링크 트램폴린에서 목적지 인텐트에 `FLAG_ACTIVITY_NO_HISTORY`가 설정되어 크래시가 발생하는 문제를 수정합니다.
앱 실행과 딥링크 이동 경로 모두 공통 `NOTIFICATION_INTENT_FLAGS`를 사용하도록 정리했습니다.

## 작업 내용
- 목적지/런처 인텐트 플래그를 `NEW_TASK | CLEAR_TOP | SINGLE_TOP` 조합으로 통일했습니다.
- `NotificationTrampolineActivityTest`를 추가해 `NO_HISTORY`가 포함되지 않고 각 경로에서 동일 플래그가 적용되는지 검증했습니다.

## 참고
`:hackle-android-sdk:testDebugUnitTest --tests io.hackle.android.ui.notification.NotificationTrampolineActivityTest` 통과했습니다.
