### PR TITLE
chore: Bump Android minSdkVersion from 21 to 24

### DIFF
--- a/hackle-android-sdk/build.gradle
+++ b/hackle-android-sdk/build.gradle
@@ -15,7 +15,7 @@ android {
     compileSdkVersion 34
 
     defaultConfig {
-        minSdkVersion 21
+        minSdkVersion 24
         targetSdkVersion 34
         versionCode 1
         versionName version


### PR DESCRIPTION
Bumps `minSdkVersion` to 24 to enable the use of native `CompletableFuture`.