### PR TITLE
refactor: simplify experiment decision APIs

### DIFF
--- a/TesterApp/src/main/java/io/hackle/android/sdk/tester/MainActivity.kt
+++ b/TesterApp/src/main/java/io/hackle/android/sdk/tester/MainActivity.kt
@@ -17,6 +17,7 @@ import io.hackle.android.Hackle
 import io.hackle.android.HackleApp
 import io.hackle.android.HackleConfig
 import io.hackle.android.app
+import io.hackle.sdk.common.PropertyOperations
 import io.hackle.sdk.common.subscription.HackleSubscriptionOperations
 import io.hackle.sdk.common.subscription.HackleSubscriptionStatus
 import java.util.concurrent.Executors
@@ -131,8 +132,9 @@ class MainActivity : AppCompatActivity() {
         findViewById<Button>(R.id.set_property_01_btn).setOnClickListener {
             val property = userService.property(R.id.property_key_01, R.id.property_value_01)
             if (property != null) {
-                Hackle.app.setUserProperty(property.first, property.second)
-
+                Hackle.app.updateUserProperties(
+                    PropertyOperations.builder().set(property.first, property.second).build()
+                )
             }
         }
 

--- a/hackle-android-sdk/src/main/java/io/hackle/android/Hackle.kt
+++ b/hackle-android-sdk/src/main/java/io/hackle/android/Hackle.kt
@@ -144,6 +144,14 @@ fun Hackle.setDeviceId(deviceId: String) = app.setDeviceId(deviceId)
  * @param key the property key
  * @param value the property value
  */
+@Deprecated(
+    "Use updateUserProperties(operations) instead.",
+    ReplaceWith(
+        "app.updateUserProperties(PropertyOperations.builder().set(key, value).build())",
+        "io.hackle.sdk.common.PropertyOperations"
+    )
+)
+@Suppress("DEPRECATION")
 fun Hackle.setUserProperty(key: String, value: Any?) = app.setUserProperty(key, value)
 
 /**

--- a/hackle-android-sdk/src/main/java/io/hackle/android/Hackle.kt
+++ b/hackle-android-sdk/src/main/java/io/hackle/android/Hackle.kt
@@ -148,7 +148,8 @@ fun Hackle.setDeviceId(deviceId: String) = app.setDeviceId(deviceId)
     "Use updateUserProperties(operations) instead.",
     ReplaceWith(
         "app.updateUserProperties(PropertyOperations.builder().set(key, value).build())",
-        "io.hackle.sdk.common.PropertyOperations"
+        "io.hackle.sdk.common.PropertyOperations",
+        "io.hackle.android.app"
     )
 )
 @Suppress("DEPRECATION")

--- a/hackle-android-sdk/src/main/java/io/hackle/android/HackleApp.kt
+++ b/hackle-android-sdk/src/main/java/io/hackle/android/HackleApp.kt
@@ -16,7 +16,6 @@ import io.hackle.android.ui.explorer.base.HackleUserExplorerService
 import io.hackle.android.ui.inappmessage.InAppMessageUi
 import io.hackle.android.ui.notification.NotificationHandler
 import io.hackle.sdk.common.*
-import io.hackle.sdk.common.Variation.Companion.CONTROL
 import io.hackle.sdk.common.decision.Decision
 import io.hackle.sdk.common.decision.FeatureFlagDecision
 import io.hackle.sdk.common.subscription.HackleSubscriptionOperations
@@ -210,28 +209,24 @@ class HackleApp internal constructor(
     /**
      * Decide the variation to expose to the user for experiment.
      *
-     * @param experimentKey    the unique key of the experiment
-     * @param defaultVariation the default variation of the experiment. MUST NOT be null
+     * @param experimentKey the unique key of the experiment
      *
-     * @return the decided [Variation] for the user, or [defaultVariation]
+     * @return the decided [Variation] for the user, or [Variation.CONTROL] if the experiment cannot be decided
      */
-    @JvmOverloads
-    fun variation(experimentKey: Long, defaultVariation: Variation = CONTROL): Variation {
-        return variationDetail(experimentKey, defaultVariation).variation
+    fun variation(experimentKey: Long): Variation {
+        return variationDetail(experimentKey).variation
     }
 
     /**
      * Decide the variation to expose to the user for experiment and returns an object that
      * describes the way the variation was decided.
      *
-     * @param experimentKey    the unique key for the experiment
-     * @param defaultVariation the default variation of the experiment. MUST NOT be null
+     * @param experimentKey the unique key for the experiment
      *
      * @return a [Decision] object
      */
-    @JvmOverloads
-    fun variationDetail(experimentKey: Long, defaultVariation: Variation = CONTROL): Decision {
-        return hackleAppCore.variationDetail(experimentKey, defaultVariation, HackleAppContext.DEFAULT)
+    fun variationDetail(experimentKey: Long): Decision {
+        return hackleAppCore.variationDetail(experimentKey, HackleAppContext.DEFAULT)
     }
 
     /**
@@ -389,6 +384,39 @@ class HackleApp internal constructor(
 
     // Deprecated
     //<editor-fold desc="Deprecated function">
+    /**
+     * Decide the variation to expose to the user for experiment.
+     *
+     * @param experimentKey    the unique key of the experiment
+     * @param defaultVariation ignored. [Variation.CONTROL] is always used when the experiment cannot be decided
+     *
+     * @return the decided [Variation] for the user, or [Variation.CONTROL] if the experiment cannot be decided
+     */
+    @Deprecated(
+        "Use variation(experimentKey) without defaultVariation instead.",
+        ReplaceWith("variation(experimentKey)")
+    )
+    fun variation(experimentKey: Long, defaultVariation: Variation): Variation {
+        return variation(experimentKey)
+    }
+
+    /**
+     * Decide the variation to expose to the user for experiment and returns an object that
+     * describes the way the variation was decided.
+     *
+     * @param experimentKey    the unique key for the experiment
+     * @param defaultVariation ignored. [Variation.CONTROL] is always used when the experiment cannot be decided
+     *
+     * @return a [Decision] object
+     */
+    @Deprecated(
+        "Use variationDetail(experimentKey) without defaultVariation instead.",
+        ReplaceWith("variationDetail(experimentKey)")
+    )
+    fun variationDetail(experimentKey: Long, defaultVariation: Variation): Decision {
+        return variationDetail(experimentKey)
+    }
+
     @Deprecated("Use showUserExplorer() instead.", ReplaceWith("showUserExplorer()"))
     fun showUserExplorer(activity: Activity) {
         showUserExplorer()

--- a/hackle-android-sdk/src/main/java/io/hackle/android/HackleApp.kt
+++ b/hackle-android-sdk/src/main/java/io/hackle/android/HackleApp.kt
@@ -120,21 +120,6 @@ class HackleApp internal constructor(
     }
 
     /**
-     * Sets a single user property.
-     *
-     * @param key the key of the property
-     * @param value the value of the property
-     * @param callback an optional callback to be executed when the operation is complete
-     */
-    @JvmOverloads
-    fun setUserProperty(key: String, value: Any?, callback: Runnable? = null) {
-        val operations = PropertyOperations.builder()
-            .set(key, value)
-            .build()
-        hackleAppCore.updateUserProperties(operations, callback)
-    }
-
-    /**
      * Updates user properties with a set of operations.
      *
      * @param operations a set of [PropertyOperations] to apply to user properties
@@ -432,6 +417,28 @@ class HackleApp internal constructor(
         log.error {
             "updatePushSubscriptionStatus does nothing. Use updatePushSubscriptions(operations) instead."
         }
+    }
+
+    /**
+     * Sets a single user property.
+     *
+     * @param key the key of the property
+     * @param value the value of the property
+     * @param callback an optional callback to be executed when the operation is complete
+     */
+    @Deprecated(
+        "Use updateUserProperties(operations) instead.",
+        ReplaceWith(
+            "updateUserProperties(PropertyOperations.builder().set(key, value).build(), callback)",
+            "io.hackle.sdk.common.PropertyOperations"
+        )
+    )
+    @JvmOverloads
+    fun setUserProperty(key: String, value: Any?, callback: Runnable? = null) {
+        val operations = PropertyOperations.builder()
+            .set(key, value)
+            .build()
+        hackleAppCore.updateUserProperties(operations, callback)
     }
     //</editor-fold>
 

--- a/hackle-android-sdk/src/main/java/io/hackle/android/internal/HackleAppCore.kt
+++ b/hackle-android-sdk/src/main/java/io/hackle/android/internal/HackleAppCore.kt
@@ -199,7 +199,6 @@ internal class HackleAppCore(
 
     fun variationDetail(
         experimentKey: Long,
-        defaultVariation: Variation,
         hackleAppContext: HackleAppContext,
     ): Decision {
         val sample = Timer.start()
@@ -207,8 +206,8 @@ internal class HackleAppCore(
             val hackleUser = userManager.hackleUser(appContext = hackleAppContext)
             core.experiment(experimentKey, hackleUser)
         } catch (t: Throwable) {
-            log.error { "Unexpected exception while deciding variation for experiment[$experimentKey]. Returning default variation[$defaultVariation]: $t" }
-            Decision.of(defaultVariation, EXCEPTION)
+            log.error { "Unexpected exception while deciding variation for experiment[$experimentKey]: $t" }
+            Decision.of(Variation.CONTROL, EXCEPTION)
         }.also {
             DecisionMetrics.experiment(sample, experimentKey, it)
         }

--- a/hackle-android-sdk/src/main/java/io/hackle/android/internal/invocator/InvocationParameters.kt
+++ b/hackle-android-sdk/src/main/java/io/hackle/android/internal/invocator/InvocationParameters.kt
@@ -126,12 +126,6 @@ internal fun InvocationParameters.phoneNumber(): String? = this["phoneNumber"] a
 internal fun InvocationParameters.experimentKey(): Long? = (this["experimentKey"] as? Number)?.toLong()
 
 /**
- * A/B 테스트의 기본 그룹(variation) 키를 반환합니다.
- * @return 기본 그룹 키. `null`이 아님.
- */
-internal fun InvocationParameters.defaultVariation(): String = this["defaultVariation"] as? String ?: "A"
-
-/**
  * 기능 플래그 키(Feature Key)를 [Long] 타입으로 반환합니다.
  * @return 기능 플래그 키 또는 `null`
  */

--- a/hackle-android-sdk/src/main/java/io/hackle/android/internal/invocator/invocation/handlers/EvaluationInvocationHandlers.kt
+++ b/hackle-android-sdk/src/main/java/io/hackle/android/internal/invocator/invocation/handlers/EvaluationInvocationHandlers.kt
@@ -9,7 +9,6 @@ import io.hackle.android.internal.invocator.invocation.InvocationResponse
 import io.hackle.android.internal.invocator.model.DecisionDto
 import io.hackle.android.internal.invocator.model.FeatureFlagDecisionDto
 import io.hackle.android.internal.invocator.model.toDto
-import io.hackle.sdk.common.Variation
 import io.hackle.sdk.common.decision.Decision
 import io.hackle.sdk.common.decision.FeatureFlagDecision
 import io.hackle.sdk.core.model.ValueType
@@ -20,9 +19,8 @@ internal abstract class AbTestInvocationHandler<R>(private val core: HackleAppCo
     override fun invoke(request: InvocationRequest): InvocationResponse<R> {
         val p = request.parameters
         val experimentKey = checkParameterNotNull(p.experimentKey(), "experimentKey")
-        val defaultVariation = Variation.fromOrControl(p.defaultVariation())
         val context = HackleAppContext.create(request.browserProperties)
-        val decision = core.variationDetail(experimentKey, defaultVariation, context)
+        val decision = core.variationDetail(experimentKey, context)
         return InvocationResponse.success(transform(decision))
     }
 

--- a/hackle-android-sdk/src/test/java/io/hackle/android/HackleAppTest.kt
+++ b/hackle-android-sdk/src/test/java/io/hackle/android/HackleAppTest.kt
@@ -511,6 +511,20 @@ class HackleAppTest {
     }
 
     @Test
+    @Suppress("DEPRECATION")
+    fun `variationDetail - deprecated 오버로드는 defaultVariation을 무시한다`() {
+        // given
+        every { core.experiment(any(), any()) } throws IllegalArgumentException()
+
+        // when
+        val actual = sut.variationDetail(42, Variation.J)
+
+        // then
+        expectThat(actual.variation).isEqualTo(Variation.A)
+        expectThat(actual.reason).isEqualTo(DecisionReason.EXCEPTION)
+    }
+
+    @Test
     fun `allVariationDetails`() {
         // given
         val hackleUser = HackleUser.builder().identifier(IdentifierType.ID, "42").build()

--- a/hackle-android-sdk/src/test/java/io/hackle/android/HackleAppTest.kt
+++ b/hackle-android-sdk/src/test/java/io/hackle/android/HackleAppTest.kt
@@ -368,6 +368,7 @@ class HackleAppTest {
     }
 
     @Test
+    @Suppress("DEPRECATION")
     fun `setUserProperty`() {
         val callback = mockk<Runnable>(relaxed = true)
         sut.setUserProperty("age", 42, callback)

--- a/hackle-android-sdk/src/test/java/io/hackle/android/HackleTest.kt
+++ b/hackle-android-sdk/src/test/java/io/hackle/android/HackleTest.kt
@@ -42,6 +42,7 @@ class HackleTest {
     private val testPushToken = "test_push_token"
 
     @Before
+    @Suppress("DEPRECATION")
     fun before() {
         MockKAnnotations.init(this, relaxUnitFun = true)
 
@@ -218,6 +219,7 @@ class HackleTest {
     }
 
     @Test
+    @Suppress("DEPRECATION")
     fun `setUserProperty should delegate to app setUserProperty`() {
         // when
         Hackle.setUserProperty(testPropertyKey, testPropertyValue)

--- a/hackle-android-sdk/src/test/java/io/hackle/android/internal/invocator/HackleInvocationTest.kt
+++ b/hackle-android-sdk/src/test/java/io/hackle/android/internal/invocator/HackleInvocationTest.kt
@@ -554,17 +554,16 @@ class HackleInvocationTest {
 
     @Test
     fun `invoke with variation`() {
-        every { app.variationDetail(any(), any<Variation>(), any()) } returns Decision.of(
+        every { app.variationDetail(any(), any()) } returns Decision.of(
             Variation.B,
             DecisionReason.DEFAULT_RULE
         )
-        val parameters = mapOf("experimentKey" to 1, "defaultVariation" to "D")
+        val parameters = mapOf("experimentKey" to 1)
         val jsonString = createJsonString("variation", parameters)
         val result = invocation.invoke(jsonString)
         verify(exactly = 1) {
             app.variationDetail(
                 withArg { assertThat(it, `is`(1)) },
-                withArg<Variation> { assertThat(it.name, `is`("D")) },
                 withArg<HackleAppContext> { assertThat(it.browserProperties, `is`(defaultBrowserProperties)) }
             )
         }
@@ -577,13 +576,12 @@ class HackleInvocationTest {
 
     @Test
     fun `invoke with variation - user 파라미터는 무시하고 현재 SDK 유저 기준으로 호출한다`() {
-        every { app.variationDetail(any(), any<Variation>(), any()) } returns Decision.of(
+        every { app.variationDetail(any(), any()) } returns Decision.of(
             Variation.B,
             DecisionReason.DEFAULT_RULE
         )
         val parameters = mapOf(
             "experimentKey" to 1,
-            "defaultVariation" to "D",
             "user" to "abcd1234"
         )
         val jsonString = createJsonString("variation", parameters)
@@ -591,7 +589,6 @@ class HackleInvocationTest {
         verify(exactly = 1) {
             app.variationDetail(
                 withArg { assertThat(it, `is`(1)) },
-                withArg<Variation> { assertThat(it.name, `is`("D")) },
                 withArg<HackleAppContext> { assertThat(it.browserProperties, `is`(defaultBrowserProperties)) }
             )
         }
@@ -616,17 +613,16 @@ class HackleInvocationTest {
 
     @Test
     fun `invoke with variation detail`() {
-        every { app.variationDetail(any(), any<Variation>(), any()) } returns Decision.of(
+        every { app.variationDetail(any(), any()) } returns Decision.of(
             Variation.B,
             DecisionReason.DEFAULT_RULE
         )
-        val parameters = mapOf("experimentKey" to 1, "defaultVariation" to "D")
+        val parameters = mapOf("experimentKey" to 1)
         val jsonString = createJsonString("variationDetail", parameters)
         val result = invocation.invoke(jsonString)
         verify(exactly = 1) {
             app.variationDetail(
                 withArg { assertThat(it, `is`(1)) },
-                withArg<Variation> { assertThat(it.name, `is`("D")) },
                 withArg<HackleAppContext> { assertThat(it.browserProperties, `is`(defaultBrowserProperties)) }
             )
         }

--- a/hackle-android-sdk/src/test/java/io/hackle/android/internal/invocator/invocation/handlers/EvaluationInvocationHandlersTest.kt
+++ b/hackle-android-sdk/src/test/java/io/hackle/android/internal/invocator/invocation/handlers/EvaluationInvocationHandlersTest.kt
@@ -47,7 +47,7 @@ class EvaluationInvocationHandlersTest {
     @Test
     fun `VariationInvocationHandler - variation 이름을 반환한다`() {
         // given
-        every { core.variationDetail(any(), any<Variation>(), any()) } returns Decision.of(
+        every { core.variationDetail(any(), any()) } returns Decision.of(
             Variation.B, DecisionReason.DEFAULT_RULE
         )
         val sut = VariationInvocationHandler(core)
@@ -64,31 +64,30 @@ class EvaluationInvocationHandlersTest {
     }
 
     @Test
-    fun `VariationInvocationHandler - defaultVariation이 없으면 A를 기본값으로 사용한다`() {
+    fun `VariationInvocationHandler - defaultVariation 파라미터는 무시된다`() {
         // given
-        every { core.variationDetail(any(), any<Variation>(), any()) } returns Decision.of(
+        every { core.variationDetail(any(), any()) } returns Decision.of(
             Variation.A, DecisionReason.DEFAULT_RULE
         )
         val sut = VariationInvocationHandler(core)
-        val params = mapOf<String, Any?>("experimentKey" to 1)
+        val params = mapOf<String, Any?>("experimentKey" to 1, "defaultVariation" to "D")
 
         // when
-        sut.invoke(request("variation", params))
+        val response = sut.invoke(request("variation", params))
 
         // then
         verify(exactly = 1) {
-            core.variationDetail(
-                1L,
-                withArg<Variation> { expectThat(it.name).isEqualTo("A") },
-                any<HackleAppContext>()
-            )
+            core.variationDetail(1L, any<HackleAppContext>())
+        }
+        expectThat(response) {
+            get { data }.isEqualTo("A")
         }
     }
 
     @Test
     fun `VariationInvocationHandler - user 파라미터는 무시된다`() {
         // given
-        every { core.variationDetail(any(), any<Variation>(), any()) } returns Decision.of(
+        every { core.variationDetail(any(), any()) } returns Decision.of(
             Variation.B, DecisionReason.DEFAULT_RULE
         )
         val sut = VariationInvocationHandler(core)
@@ -99,7 +98,7 @@ class EvaluationInvocationHandlersTest {
 
         // then
         verify(exactly = 1) {
-            core.variationDetail(any(), any<Variation>(), any<HackleAppContext>())
+            core.variationDetail(any(), any<HackleAppContext>())
         }
     }
 
@@ -116,7 +115,7 @@ class EvaluationInvocationHandlersTest {
     @Test
     fun `VariationDetailInvocationHandler - DecisionDto를 반환한다`() {
         // given
-        every { core.variationDetail(any(), any<Variation>(), any()) } returns Decision.of(
+        every { core.variationDetail(any(), any()) } returns Decision.of(
             Variation.B, DecisionReason.DEFAULT_RULE
         )
         val sut = VariationDetailInvocationHandler(core)


### PR DESCRIPTION
## 개요
experiment decision API에서 `defaultVariation` 파라미터를 제거하고, 결정 실패 시 항상 `Variation.CONTROL`을 사용하도록 정리합니다.
기존 `defaultVariation` 오버로드는 deprecated로 유지하되 전달된 값을 무시하도록 계약을 명확히 했습니다.
`setUserProperty`는 `updateUserProperties` 사용을 권장하도록 deprecated 처리했습니다.

## 주요 변경사항
| 카테고리 | 내용 |
|----------|------|
| Experiment API | `variation`, `variationDetail`의 기본 API에서 `defaultVariation` 파라미터 제거 |
| Deprecated API | 기존 `defaultVariation` 오버로드는 deprecated로 유지하고 `Variation.CONTROL` 기준으로 동작하도록 변경 |
| Invocation | Web invocation의 `defaultVariation` 파라미터 파싱 및 전달 제거 |
| User Properties | `setUserProperty`를 deprecated 처리하고 `updateUserProperties`로 대체 안내 추가 |
| TesterApp | deprecated `setUserProperty` 호출을 `updateUserProperties` 호출로 변경 |
| Tests | deprecated 오버로드의 `defaultVariation` 무시 계약과 invocation 변경 사항 테스트 반영 |