### PR TITLE
refactor: deprecate app mode config

### DIFF
--- a/hackle-android-sdk/src/main/java/io/hackle/android/HackleConfig.kt
+++ b/hackle-android-sdk/src/main/java/io/hackle/android/HackleConfig.kt
@@ -211,7 +211,7 @@ class HackleConfig private constructor(builder: Builder) {
          * @param evaluationMode the evaluation mode to set
          * @return this builder instance
          */
-        fun mode(evaluationMode: EvaluationMode) = apply {
+        fun evaluationMode(evaluationMode: EvaluationMode) = apply {
             this.evaluationMode = evaluationMode
         }
 

--- a/hackle-android-sdk/src/main/java/io/hackle/android/HackleConfig.kt
+++ b/hackle-android-sdk/src/main/java/io/hackle/android/HackleConfig.kt
@@ -221,6 +221,9 @@ class HackleConfig private constructor(builder: Builder) {
          * @param mode the application mode to set
          * @return this builder instance
          */
+        @Deprecated(
+            message = "App mode configuration is deprecated. WEB_VIEW_WRAPPER is no longer recommended, and NATIVE is the default."
+        )
         fun mode(mode: HackleAppMode) = apply {
             this.appMode = mode
         }

--- a/hackle-android-sdk/src/main/java/io/hackle/android/internal/workspace/config/DefaultWorkspaceConfig.kt
+++ b/hackle-android-sdk/src/main/java/io/hackle/android/internal/workspace/config/DefaultWorkspaceConfig.kt
@@ -1,5 +1,6 @@
 package io.hackle.android.internal.workspace.config
 
+import io.hackle.sdk.common.EvaluationMode
 import io.hackle.sdk.common.PropertiesBuilder
 import io.hackle.sdk.core.model.Bucket
 import io.hackle.sdk.core.model.Container
@@ -69,6 +70,7 @@ internal class DefaultWorkspaceConfig(
 
     override fun toProperties(): Map<String, Any> {
         return PropertiesBuilder()
+            .add("evaluation_mode", EvaluationMode.LOCAL.name)
             .add("config_modified_at", modifiedAt)
             .build()
     }

--- a/hackle-android-sdk/src/main/java/io/hackle/android/internal/workspace/evaluation/DefaultWorkspaceEvaluation.kt
+++ b/hackle-android-sdk/src/main/java/io/hackle/android/internal/workspace/evaluation/DefaultWorkspaceEvaluation.kt
@@ -3,6 +3,7 @@ package io.hackle.android.internal.workspace.evaluation
 import io.hackle.android.internal.workspace.config.WorkspaceDto
 import io.hackle.android.internal.workspace.config.parseEnumOrNull
 import io.hackle.android.internal.workspace.evaluation.model.*
+import io.hackle.sdk.common.EvaluationMode
 import io.hackle.sdk.common.PropertiesBuilder
 import io.hackle.sdk.core.model.Entity
 import io.hackle.sdk.core.model.Experiment.Type.AB_TEST
@@ -64,6 +65,7 @@ internal class DefaultWorkspaceEvaluation(
 
     override fun toProperties(): Map<String, Any> {
         return PropertiesBuilder()
+            .add("evaluation_mode", EvaluationMode.REMOTE.name)
             .add("config_modified_at", modifiedAt)
             .add("remote_evaluated_at", evaluatedAt)
             .add("remote_full_evaluated_at", fullEvaluatedAt)

--- a/hackle-android-sdk/src/test/java/io/hackle/android/HackleAppTest.kt
+++ b/hackle-android-sdk/src/test/java/io/hackle/android/HackleAppTest.kt
@@ -107,6 +107,7 @@ class HackleAppTest {
 
     private lateinit var sut: HackleApp
 
+    @Suppress("DEPRECATION")
     @Before
     fun before() {
         MockKAnnotations.init(this, relaxUnitFun = true)

--- a/hackle-android-sdk/src/test/java/io/hackle/android/HackleAppsTest.kt
+++ b/hackle-android-sdk/src/test/java/io/hackle/android/HackleAppsTest.kt
@@ -104,6 +104,7 @@ class HackleAppsTest {
         expectThat(result.config.appMode).isEqualTo(HackleAppMode.NATIVE)
     }
 
+    @Suppress("DEPRECATION")
     @Test
     fun `HackleApps create should return HackleApp instance with custom config`() {
         // given

--- a/hackle-android-sdk/src/test/java/io/hackle/android/HackleConfigTest.kt
+++ b/hackle-android-sdk/src/test/java/io/hackle/android/HackleConfigTest.kt
@@ -42,6 +42,7 @@ class HackleConfigTest {
         expectThat(result.automaticAppLifecycleTracking).isEqualTo(true)
     }
 
+    @Suppress("DEPRECATION")
     @Test
     fun `HackleConfig builder should create config with custom values`() {
         // when
@@ -138,6 +139,7 @@ class HackleConfigTest {
         }
     }
 
+    @Suppress("DEPRECATION")
     @Test
     fun `mode`() {
         configTests(HackleConfig::appMode to HackleAppMode.NATIVE)

--- a/hackle-android-sdk/src/test/java/io/hackle/android/HackleConfigTest.kt
+++ b/hackle-android-sdk/src/test/java/io/hackle/android/HackleConfigTest.kt
@@ -5,6 +5,7 @@ import io.mockk.every
 import io.mockk.mockkStatic
 import io.mockk.unmockkStatic
 import org.junit.After
+import io.hackle.sdk.common.EvaluationMode
 import io.hackle.sdk.common.HackleSessionPolicy
 import io.hackle.sdk.common.HackleSessionPersistCondition
 import io.hackle.sdk.common.HackleSessionTimeoutCondition
@@ -145,6 +146,17 @@ class HackleConfigTest {
             HackleConfig::sessionTracking to false
         ) {
             mode(HackleAppMode.WEB_VIEW_WRAPPER)
+        }
+    }
+
+    @Test
+    fun `evaluationMode`() {
+        configTests(HackleConfig::evaluationMode to EvaluationMode.LOCAL)
+        configTests(HackleConfig::evaluationMode to EvaluationMode.REMOTE) {
+            evaluationMode(EvaluationMode.REMOTE)
+        }
+        configTests(HackleConfig::evaluationMode to EvaluationMode.LOCAL) {
+            evaluationMode(EvaluationMode.LOCAL)
         }
     }
 

--- a/hackle-android-sdk/src/test/java/io/hackle/android/internal/invocator/web/HackleJavascriptInterfaceTest.kt
+++ b/hackle-android-sdk/src/test/java/io/hackle/android/internal/invocator/web/HackleJavascriptInterfaceTest.kt
@@ -14,6 +14,7 @@ import strikt.assertions.isEqualTo
 
 class HackleJavascriptInterfaceTest {
 
+    @Suppress("DEPRECATION")
     private fun app(
         sdk: Sdk = Sdk("SDK_KEY", "name", "version"),
         mode: HackleAppMode,

--- a/hackle-android-sdk/src/test/java/io/hackle/android/internal/workspace/config/DefaultWorkspaceConfigTest.kt
+++ b/hackle-android-sdk/src/test/java/io/hackle/android/internal/workspace/config/DefaultWorkspaceConfigTest.kt
@@ -179,9 +179,14 @@ class DefaultWorkspaceConfigTest {
     }
 
     @Test
-    fun `toProperties - config_modified_at을 포함한다`() {
-        expectThat(workspace(modifiedAt = "42").toProperties()) isEqualTo mapOf<String, Any>("config_modified_at" to "42")
-        expectThat(workspace(modifiedAt = null).toProperties()) isEqualTo emptyMap()
+    fun `toProperties - evaluation_mode와 config_modified_at을 포함한다`() {
+        expectThat(workspace(modifiedAt = "42").toProperties()) isEqualTo mapOf<String, Any>(
+            "evaluation_mode" to "LOCAL",
+            "config_modified_at" to "42",
+        )
+        expectThat(workspace(modifiedAt = null).toProperties()) isEqualTo mapOf<String, Any>(
+            "evaluation_mode" to "LOCAL",
+        )
     }
 
     private fun experimentDto(

--- a/hackle-android-sdk/src/test/java/io/hackle/android/internal/workspace/evaluation/DefaultWorkspaceEvaluationTest.kt
+++ b/hackle-android-sdk/src/test/java/io/hackle/android/internal/workspace/evaluation/DefaultWorkspaceEvaluationTest.kt
@@ -277,6 +277,7 @@ class DefaultWorkspaceEvaluationTest {
 
         // when & then
         expectThat(DefaultWorkspaceEvaluation.from(dto, fullEvaluatedAt = 99).toProperties()) isEqualTo mapOf(
+            "evaluation_mode" to "REMOTE",
             "config_modified_at" to "42",
             "remote_evaluated_at" to 100L,
             "remote_full_evaluated_at" to 99L,
@@ -292,6 +293,7 @@ class DefaultWorkspaceEvaluationTest {
 
         // when & then
         expectThat(DefaultWorkspaceEvaluation.from(dto).toProperties()) isEqualTo mapOf(
+            "evaluation_mode" to "REMOTE",
             "config_modified_at" to "42",
             "remote_evaluated_at" to 100L,
         )

--- a/hackle-android-sdk/src/test/java/io/hackle/android/support/Workspaces.kt
+++ b/hackle-android-sdk/src/test/java/io/hackle/android/support/Workspaces.kt
@@ -3,6 +3,8 @@ package io.hackle.android.support
 import io.hackle.android.internal.workspace.config.*
 import io.hackle.android.internal.workspace.evaluation.WorkspaceEvaluationContext
 import io.hackle.android.internal.workspace.evaluation.model.*
+import io.hackle.sdk.common.EvaluationMode
+import io.hackle.sdk.common.PropertiesBuilder
 import io.hackle.sdk.core.model.*
 import io.hackle.sdk.core.workspace.config.WorkspaceConfig
 import io.hackle.sdk.core.workspace.config.entity.ExperimentConfig
@@ -384,8 +386,10 @@ internal object Workspaces {
         }
 
         override fun toProperties(): Map<String, Any> {
-            val modifiedAt = metadata.modifiedAt ?: return emptyMap()
-            return mapOf("config_modified_at" to modifiedAt)
+            return PropertiesBuilder()
+                .add("evaluation_mode", EvaluationMode.LOCAL.name)
+                .add("config_modified_at", metadata.modifiedAt)
+                .build()
         }
     }
 
@@ -421,8 +425,11 @@ internal object Workspaces {
         }
 
         override fun toProperties(): Map<String, Any> {
-            val modifiedAt = metadata.modifiedAt ?: return emptyMap()
-            return mapOf("config_modified_at" to modifiedAt)
+            return PropertiesBuilder()
+                .add("evaluation_mode", EvaluationMode.REMOTE.name)
+                .add("config_modified_at", metadata.modifiedAt)
+                .add("remote_evaluated_at", metadata.evaluatedAt)
+                .build()
         }
     }
 }


### PR DESCRIPTION
## 개요
`HackleConfig.Builder.mode(HackleAppMode)`를 deprecated 처리하고, 평가 모드 설정 API를 `evaluationMode()`로 분리했습니다.
워크스페이스 속성에 로컬/리모트 평가 모드 정보를 포함하도록 개선했습니다.

## 작업 내용
- `HackleConfig.Builder.evaluationMode(EvaluationMode)` API 추가
- 기존 `mode(HackleAppMode)`에 deprecation 메시지 추가
- `DefaultWorkspaceConfig.toProperties()`에 `evaluation_mode=LOCAL` 추가
- `DefaultWorkspaceEvaluation.toProperties()`에 `evaluation_mode=REMOTE` 추가
- 관련 테스트와 테스트용 workspace fixture 업데이트

## 사용 예제
```kotlin
val config = HackleConfig.builder()
    .evaluationMode(EvaluationMode.REMOTE)
    .build()
```